### PR TITLE
feat: 게시물 좋아요 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/config/ExternalApiConfig.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/config/ExternalApiConfig.java
@@ -1,0 +1,37 @@
+package com.wanted.teamr.snsfeedintegration.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * application.yml에 저장된 데이터 중 {@code @ConfigurationProperties(prefix = ~~~)}에서
+ * prefix값으로 선언된 데이터를 불러옵니다.
+ * <p>
+ * 외부 API 호출에 대한 정보(2023-10-26 기준 domain 정보만)를 yaml파일로 관리하려고
+ * 생성했으며, sns api 기준 {@code Map<String, String>} 타입으로 관리됩니다.
+ * <p>
+ * sns api 기준으로 {@code snsApiDomains.get("instagram")}으로 조회하면
+ * {@code "https://www.facebook.com/"}을 반환합니다.
+ */
+@Getter
+@Component
+@ConfigurationProperties(prefix = "external-api")
+public class ExternalApiConfig {
+    private Map<String, String> snsApiDomains;
+
+    /**
+     * Set 함수를 만드는 것을 선호하진 않으나 Set 함수가 없을 때 다음 예외가 발생했습니다.
+     * java.lang.IllegalStateException: No setter found for property: sns-api-domains
+     * <p>
+     * {@code @ConfigurationProperties}로 property를 읽어올 때 Set 함수가 필요한지 set 함수를 만들고
+     * 나서 정상 작동 했습니다.
+     *
+     * @param snsApiDomains
+     */
+    public void setSnsApiDomains(Map<String, String> snsApiDomains) {
+        this.snsApiDomains = snsApiDomains;
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/config/ExternalApiConfig.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/config/ExternalApiConfig.java
@@ -22,6 +22,8 @@ import java.util.Map;
 public class ExternalApiConfig {
     private Map<String, String> snsApiDomains;
 
+    private Map<String, String> postPath;
+
     /**
      * Set 함수를 만드는 것을 선호하진 않으나 Set 함수가 없을 때 다음 예외가 발생했습니다.
      * java.lang.IllegalStateException: No setter found for property: sns-api-domains
@@ -33,5 +35,9 @@ public class ExternalApiConfig {
      */
     public void setSnsApiDomains(Map<String, String> snsApiDomains) {
         this.snsApiDomains = snsApiDomains;
+    }
+
+    public void setPostPath(Map<String, String> postPath) {
+        this.postPath = postPath;
     }
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
@@ -1,18 +1,16 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
 import com.wanted.teamr.snsfeedintegration.service.PostService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
-
-    public PostController(PostService postService) {
-        this.postService = postService;
-    }
 
     @PostMapping("/api/posts/{postId}/like")
     public ResponseEntity<?> likePost(@PathVariable("postId") Long postId) {

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
@@ -1,7 +1,22 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
+import com.wanted.teamr.snsfeedintegration.service.PostService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class PostController {
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @PostMapping("/api/posts/{postId}/like")
+    public ResponseEntity<?> likePost(@PathVariable("postId") Long postId) {
+        postService.likePost(postId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
@@ -3,20 +3,22 @@ package com.wanted.teamr.snsfeedintegration.domain;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Post extends BaseEntity {
 
@@ -52,4 +54,22 @@ public class Post extends BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+
+    public Post(String contentId, SnsType type,
+                String title, String content, Long viewCount, Long likeCount,
+                Long shareCount, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.contentId = contentId;
+        this.type = type;
+        this.title = title;
+        this.content = content;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.shareCount = shareCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public void increaseLikeCount() {
+        likeCount += 1;
+    }
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -54,10 +55,10 @@ public class Post extends BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-
-    public Post(String contentId, SnsType type,
-                String title, String content, Long viewCount, Long likeCount,
-                Long shareCount, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    @Builder
+    private Post(String contentId, SnsType type, String title, String content,
+                 Long viewCount, Long likeCount, Long shareCount, LocalDateTime createdAt,
+                 LocalDateTime updatedAt) {
         this.contentId = contentId;
         this.type = type;
         this.title = title;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/SnsType.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/SnsType.java
@@ -1,6 +1,5 @@
 package com.wanted.teamr.snsfeedintegration.domain;
 
 public enum SnsType {
-
-
+    INSTAGRAM, FACEBOOK, TWITTER, THREADS;
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     DUPLICATE_ACCOUNT_NAME_ERROR("이미 같은 이름의 계정이 존재합니다", HttpStatus.BAD_REQUEST),
+    POST_NOT_FOUND("해당 게시물이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepository.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepository.java
@@ -1,7 +1,16 @@
 package com.wanted.teamr.snsfeedintegration.repository;
 
 import com.wanted.teamr.snsfeedintegration.domain.Post;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Post p where p.id = :id")
+    Optional<Post> findByIdForUpdate(Long id);
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
@@ -19,7 +19,7 @@ public class PostService {
         Post post = postRepository.findByIdForUpdate(postId)
                                   .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-        snsService.likePost(post.getContent(), post.getType());
+        snsService.likePost(post.getContentId(), post.getType());
 
         post.increaseLikeCount();
         postRepository.save(post);

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
@@ -4,18 +4,15 @@ import com.wanted.teamr.snsfeedintegration.domain.Post;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
     private final SnsService snsService;
-
-    public PostService(final PostRepository postRepository, final SnsService snsService) {
-        this.postRepository = postRepository;
-        this.snsService = snsService;
-    }
 
     @Transactional
     public void likePost(Long postId) {

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
@@ -1,7 +1,30 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
+import com.wanted.teamr.snsfeedintegration.domain.Post;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
+import com.wanted.teamr.snsfeedintegration.repository.PostRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PostService {
+    private final PostRepository postRepository;
+    private final SnsService snsService;
+
+    public PostService(final PostRepository postRepository, final SnsService snsService) {
+        this.postRepository = postRepository;
+        this.snsService = snsService;
+    }
+
+    @Transactional
+    public void likePost(Long postId) {
+        Post post = postRepository.findByIdForUpdate(postId)
+                                  .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        snsService.likePost(post.getContent(), post.getType());
+
+        post.increaseLikeCount();
+        postRepository.save(post);
+    }
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
@@ -2,6 +2,7 @@ package com.wanted.teamr.snsfeedintegration.service;
 
 import com.wanted.teamr.snsfeedintegration.config.ExternalApiConfig;
 import com.wanted.teamr.snsfeedintegration.domain.SnsType;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 /**
@@ -10,14 +11,10 @@ import org.springframework.stereotype.Service;
  * 본 서비스가 아닌 외부 SNS 서비스의 기능을 실제로 동작하기 위해 외부 API를 호출합니다.
  */
 @Service
+@RequiredArgsConstructor
 public class SnsService {
     private final WebClientService webClientService;
     private final ExternalApiConfig externalApiConfig;
-
-    public SnsService(WebClientService webClientService, ExternalApiConfig externalApiConfig) {
-        this.webClientService = webClientService;
-        this.externalApiConfig = externalApiConfig;
-    }
 
     /**
      * 본 서비스가 아닌 실제 외부 SNS 서비스에서의 좋아요 API를 호출하여

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
@@ -1,0 +1,51 @@
+package com.wanted.teamr.snsfeedintegration.service;
+
+import com.wanted.teamr.snsfeedintegration.config.ExternalApiConfig;
+import com.wanted.teamr.snsfeedintegration.domain.SnsType;
+import org.springframework.stereotype.Service;
+
+/**
+ * 외부 SNS 서비스에서 동작하는 좋아요, 공유 기능 등을 처리합니다.
+ * <p>
+ * 본 서비스가 아닌 외부 SNS 서비스의 기능을 실제로 동작하기 위해 외부 API를 호출합니다.
+ */
+@Service
+public class SnsService {
+    private final WebClientService webClientService;
+    private final ExternalApiConfig externalApiConfig;
+
+    public SnsService(WebClientService webClientService, ExternalApiConfig externalApiConfig) {
+        this.webClientService = webClientService;
+        this.externalApiConfig = externalApiConfig;
+    }
+
+    /**
+     * 본 서비스가 아닌 실제 외부 SNS 서비스에서의 좋아요 API를 호출하여
+     * 좋아요 기능을 처리합니다.
+     *
+     * @param contentId 게시물이 해당하는 SNS에서 관리되는 고유 인식 값
+     * @param snsType   SNS 서비스 종류
+     * @return 외부 SNS 서비스 좋아요 기능 동작 성공 여부
+     */
+    public boolean likePost(String contentId, SnsType snsType) {
+        String domain = externalApiConfig.getSnsApiDomains()
+                                         .get(snsType.name());
+        String path = String.format(externalApiConfig.getPostPath()
+                                                     .get("like"), contentId);
+        String url = String.format("%s%s", domain, path);
+
+        // TODO: 외부 API 호출 통신 구현
+        /**
+         * 외부 API 통신에 대한 로직을 보여주기 위한 코드로
+         * webClientService구현체 webClientServiceImpl에서 send 함수가 항상 null을 반환합니다.
+         * 그래서 아래 코드의 주석 처리를 지우면 외부 API 통신에 대해 항상 실패합니다.
+         */
+        /*HttpResponse response = webClientService.send(url, HttpMethod.POST);
+        int httpStatus = response.statusCode();
+        if (httpStatus != HttpStatus.OK.value()) {
+            // throw exception
+        }*/
+
+        return true;
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/WebClientService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/WebClientService.java
@@ -1,0 +1,25 @@
+package com.wanted.teamr.snsfeedintegration.service;
+
+
+import org.springframework.http.HttpMethod;
+
+import java.net.http.HttpResponse;
+
+/**
+ * 게시물 좋아요, 공유 기능 개발을 위한 요소로 외부 API 통신 작업을 추상화한 interface 입니다.
+ * 이번 과제에서는 외부 API 호출이 실제로 동작하지 않습니다.
+ */
+public interface WebClientService {
+
+    /**
+     * Http API 통신
+     * <p>
+     * 실제 API 통신 라이브러리에서는 Query Parameter, Header등의 정보도 포함해서 호출 하겠지만,
+     * 게시물 좋아요, 공유 기능 개발을 위한 요소이므로 간추려서
+     * URL과 Http Method만 입력 받게 했습니다.
+     * @param url URL
+     * @param method Http Method
+     * @return Http Response
+     */
+    public HttpResponse send(String url, HttpMethod method);
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/WebClientServiceImpl.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/WebClientServiceImpl.java
@@ -1,0 +1,17 @@
+package com.wanted.teamr.snsfeedintegration.service;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+
+import java.net.http.HttpResponse;
+
+@Service
+public class WebClientServiceImpl implements WebClientService {
+    // private final WebClient webClient; // 외부 서버와 통신하기 위해 선택한 라이브러리
+
+    @Override
+    public HttpResponse send(String url, HttpMethod method) {
+        // TODO: 외부 서버 통신 라이브러리에 맞게 API 통신 구현
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,9 @@ spring:
       mode: always
       data-locations: classpath:db/data.sql
 
+  config:
+    import: external-api-config.yml
+
 logging:
   level:
     sql: trace

--- a/src/main/resources/external-api-config.yml
+++ b/src/main/resources/external-api-config.yml
@@ -7,3 +7,4 @@ external-api:
 
   post-path:
     like: "likes/%s"
+

--- a/src/main/resources/external-api-config.yml
+++ b/src/main/resources/external-api-config.yml
@@ -4,3 +4,6 @@ external-api:
     facebook: "https://www.twitter.com/"
     twitter: "https://www.instagram.com/"
     threads: "https://www.threads.net/"
+
+  post-path:
+    like: "likes/%s"

--- a/src/main/resources/external-api-config.yml
+++ b/src/main/resources/external-api-config.yml
@@ -1,0 +1,6 @@
+external-api:
+  sns-api-domains:
+    instagram: "https://www.facebook.com/"
+    facebook: "https://www.twitter.com/"
+    twitter: "https://www.instagram.com/"
+    threads: "https://www.threads.net/"

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -30,10 +30,17 @@ class PostServiceConcurrencyTest {
     @DisplayName("게시물 좋아요 기능 멀티 스레드로 동시에 총 1000번 요청")
     public void postLikeMultiThreadRequest1000() throws InterruptedException {
         // given: 좋아요 수가 0인 게시글 설정
-        Post post = new Post("123456789", SnsType.FACEBOOK, "게시글 제목",
-                "게시글 내용", 0L, 0L, 0L,
-                LocalDateTime.of(2023, 7, 7, 5, 23, 33),
-                LocalDateTime.of(2023, 7, 7, 5, 24, 20));
+        Post post = Post.builder()
+                        .contentId("123456789")
+                        .type(SnsType.FACEBOOK)
+                        .title("게시물 제목")
+                        .content("게시물 내용")
+                        .viewCount(0L)
+                        .likeCount(0L)
+                        .shareCount(0L)
+                        .createdAt(LocalDateTime.of(2023, 7, 7, 5, 23, 33))
+                        .updatedAt(LocalDateTime.of(2023, 7, 7, 5, 23, 33))
+                        .build();
         postRepository.save(post);
         assertThat(post.getLikeCount()).isEqualTo(0L);
 

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -1,0 +1,69 @@
+package com.wanted.teamr.snsfeedintegration.service;
+
+import com.wanted.teamr.snsfeedintegration.domain.Post;
+import com.wanted.teamr.snsfeedintegration.domain.SnsType;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import com.wanted.teamr.snsfeedintegration.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest
+class PostServiceConcurrencyTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PostService postService;
+
+    @Test
+    @DisplayName("게시물 좋아요 기능 멀티 스레드로 동시에 총 1000번 요청")
+    public void postLikeMultiThreadRequest1000() throws InterruptedException {
+        // given: 좋아요 수가 0인 게시글 설정
+        Post post = new Post("123456789", SnsType.FACEBOOK, "게시글 제목",
+                "게시글 내용", 0L, 0L, 0L,
+                LocalDateTime.of(2023, 7, 7, 5, 23, 33),
+                LocalDateTime.of(2023, 7, 7, 5, 24, 20));
+        postRepository.save(post);
+        assertThat(post.getLikeCount()).isEqualTo(0L);
+
+        int totalExecutedCnt = 1000;
+        int threadCnt = 16;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCnt);
+        CountDownLatch latch = new CountDownLatch(totalExecutedCnt);
+
+        // when: threadCnt개 만큼 스레드가 멀티스레드 방식으로 총 totalExecutedCnt번 게시글 좋아요 요청
+        for (int idx = 0; idx < totalExecutedCnt; idx++) {
+            int finalIdx = idx;
+            executorService.execute(() -> {
+                try {
+                    postService.likePost(post.getId());
+                } catch (CustomException ex) {
+                    System.out.println(ex.getErrorCode());
+                } catch (Exception ex) {
+                    System.out.println(ex);
+                } finally {
+                    // CountDownLatch를 줄여 스레드가 완료됨을 알림
+                    latch.countDown();
+                }
+            });
+        }
+        // 모든 스레드가 완료될 때까지 대기
+        latch.await();
+
+        // then: 게시글의 좋아요 수가 총 실행 횟수인 totalExecutedCnt와 같아야 한다
+        Post samePost = postRepository.findById(post.getId()).get();
+        assertThat(samePost.getLikeCount()).isEqualTo(totalExecutedCnt);
+        postRepository.delete(samePost);
+    }
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -51,7 +51,6 @@ class PostServiceConcurrencyTest {
 
         // when: threadCnt개 만큼 스레드가 멀티스레드 방식으로 총 totalExecutedCnt번 게시글 좋아요 요청
         for (int idx = 0; idx < totalExecutedCnt; idx++) {
-            int finalIdx = idx;
             executorService.execute(() -> {
                 try {
                     postService.likePost(post.getId());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,3 +10,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+  config:
+    import: external-api-config.yml


### PR DESCRIPTION
## 📃 설명

- resolves #13 

## 🔨 작업 내용

1. 외부 SNS 서비스 기능 담당하는 클래스 생성 (SnsService)
   - sns type에 따른 api 호출 url을 만들고 가상의 외부 API 통신 서비스를 통해 외부 SNS 서비스의 좋아요 요청 담당
   - 공유 기능도 해당 Service 클래스에서 함수 하나만 추가할 예정
3. 외부 API 호출 기능 추상화 (WebClientService, WebClientServiceImple)
   - `SnsService` 에서 외부 API 호출에 대한 로직을 표현하고 싶어서 만들었습니다.
   - 기능 개발을 위한 요소로, 실제로 외부 API 호출은 동작하지 않습니다.
3. 외부 API 호출 정보 yaml 파일로 관리
   - 다른 SNS가 추가될 수도 있고 본 서비스가 발전하면서 SNS외에 아예 다른 외부 API를 호출할 수도 있어서 외부 API 호출과 관련된 정보를 따로 파일로 관리
   - domain 정보외에 API 통신을 위한 key 값 등 secret한 정보를 관리해야 될 수도 있어서 `external-api-config.yml` 파일로 관리
   - `application.yml` 에서는 `external-api-config.yml` 를 import 합니다.
   - SNS API domain 정보를 Map 타입으로 다루고자 ExternalApiConfig을 따로 만들고 `@ConfigurationProperties`를 이용하여 스캔 
5. 동시성 테스트 작성
`PostServiceConcurrencyTest` 에서 16개의 스레드가 멀티스레딩 방식으로 좋아요 요청
  a. 게시물 좋아요 요청 함수에서 `@Transactional`만 사용 (MySQL default isolation level = Repeatable Read)
    - 결과 : expected: 1000L, but was: 123L
  
    b. 게시물 좋아요 요청 함수에서 isolation level 최대로 `@Transactional(isolation = Isolation.SERIALIZABLE)`
    - 결과 : expected: 1000L, but was: 324L
    - `SERIALIZABLE`로만 올려도 되지 않을까 했는데 실패
    - 아래와 같은 에러 메시지 출력됨
    - `SqlExceptionHelper - Deadlock detected. The current transaction was rolled back. Details: "POST"; SQL statement:`
    - `org.springframework.dao.CannotAcquireLockException: could not execute statement [Deadlock detected. The current transaction was rolled back.`

    **c. 비관전 잠금(Pessimistic Lock) 사용** - 최종 선택한 방법
   - 테스트 통과
   - Repository에 따로 함수 만들어서 조회
``` java
// PostRepository.java
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("select p from Post p where p.id = :id")
Optional<Post> findByIdForUpdate(Long id);
```

## 💬 기타 사항

- 이번 PR에서 PostService, SnsService 등의 단위 테스트 작성하려 했으나 바로 다음 PR에서 테스트 코드 작성하겠습니다.
- `PostServiceConcurrencyTest` 에 작성한 동시성 테스트에서 테스트 클래스나 함수에 `@Transactional`을 붙이면 테스트에 사용할 새로운 스레드에서 `postService.likePost(post.getId());` 를 실행할 때 미리 저장한 게시물을 찾을 수 없어 테스트가 실패합니다.
- 그래서 `@Transactional` 을 일단 떼고 작성했고 다른 테스트에 영향이 덜 가도록 테스트 함수 마지막 줄에 삭제 코드`postRepository.delete(samePost);` 을 작성했습니다.