### PR TITLE
feat/#14 통계 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/java,windows,macos,gradle,intellij+all
+
+# QueryDSL: QClass path
+generated/

--- a/build.gradle
+++ b/build.gradle
@@ -59,3 +59,12 @@ configurations {
 		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
 	}
 }
+
+// QueryDSL 설정
+def querydslSrcDir = 'src/main/generated'
+clean {
+	delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/config/QuerydslConfig.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.wanted.teamr.snsfeedintegration.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -19,7 +19,7 @@ public class StatisticsController {
     private final StatisticsService statisticsService;
 
     @GetMapping("/api/statistics")
-    public ResponseEntity<List<StatisticsGetResponse>> getStatistics(@RequestParam StatisticsGetRequest statisticsGetRequest) {
+    public ResponseEntity<List<StatisticsGetResponse>> getStatistics(@ModelAttribute StatisticsGetRequest statisticsGetRequest) {
         //TODO: 시큐리티 Merge 후 세션정보(accountName) 받기 위해 재작업 필요.
         String tempAccountName = "member1";
         List<StatisticsGetResponse> statisticsGetResponses = statisticsService.getStatistics(statisticsGetRequest, tempAccountName);

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
@@ -1,5 +1,6 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
+import com.wanted.teamr.snsfeedintegration.domain.UserDetailsImpl;
 import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetRequest;
 import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetResponse;
 import com.wanted.teamr.snsfeedintegration.service.StatisticsService;
@@ -7,6 +8,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,10 +20,10 @@ public class StatisticsController {
     private final StatisticsService statisticsService;
 
     @GetMapping("/api/statistics")
-    public ResponseEntity<List<StatisticsGetResponse>> getStatistics(@ModelAttribute @Valid StatisticsGetRequest statisticsGetRequest) {
-        //TODO: 시큐리티 Merge 후 세션정보(accountName) 받기 위해 재작업 필요.
-        String tempAccountName = "member1";
-        List<StatisticsGetResponse> statisticsGetResponses = statisticsService.getStatistics(statisticsGetRequest, tempAccountName);
+    public ResponseEntity<List<StatisticsGetResponse>> getStatistics(@ModelAttribute @Valid StatisticsGetRequest statisticsGetRequest,
+                                                                     @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        String memberAccountName = userDetails.getMember().getAccountName();
+        List<StatisticsGetResponse> statisticsGetResponses = statisticsService.getStatistics(statisticsGetRequest, memberAccountName);
         return ResponseEntity.ok(statisticsGetResponses);
     }
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
@@ -6,13 +6,11 @@ import com.wanted.teamr.snsfeedintegration.service.StatisticsService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class StatisticsController {

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
@@ -1,0 +1,28 @@
+package com.wanted.teamr.snsfeedintegration.controller;
+
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetRequest;
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetResponse;
+import com.wanted.teamr.snsfeedintegration.service.StatisticsService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping("/api/statistics")
+    public ResponseEntity<List<StatisticsGetResponse>> getStatistics(@RequestParam StatisticsGetRequest statisticsGetRequest) {
+        //TODO: 시큐리티 Merge 후 세션정보(accountName) 받기 위해 재작업 필요.
+        String tempAccountName = "member1";
+        List<StatisticsGetResponse> statisticsGetResponses = statisticsService.getStatistics(statisticsGetRequest, tempAccountName);
+        return ResponseEntity.ok(statisticsGetResponses);
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsController.java
@@ -3,6 +3,7 @@ package com.wanted.teamr.snsfeedintegration.controller;
 import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetRequest;
 import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetResponse;
 import com.wanted.teamr.snsfeedintegration.service.StatisticsService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +20,7 @@ public class StatisticsController {
     private final StatisticsService statisticsService;
 
     @GetMapping("/api/statistics")
-    public ResponseEntity<List<StatisticsGetResponse>> getStatistics(@ModelAttribute StatisticsGetRequest statisticsGetRequest) {
+    public ResponseEntity<List<StatisticsGetResponse>> getStatistics(@ModelAttribute @Valid StatisticsGetRequest statisticsGetRequest) {
         //TODO: 시큐리티 Merge 후 세션정보(accountName) 받기 위해 재작업 필요.
         String tempAccountName = "member1";
         List<StatisticsGetResponse> statisticsGetResponses = statisticsService.getStatistics(statisticsGetRequest, tempAccountName);

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/StatisticsType.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/StatisticsType.java
@@ -1,0 +1,5 @@
+package com.wanted.teamr.snsfeedintegration.domain;
+
+public enum StatisticsType {
+    DATE, HOUR
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/StatisticsValue.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/StatisticsValue.java
@@ -1,0 +1,5 @@
+package com.wanted.teamr.snsfeedintegration.domain;
+
+public enum StatisticsValue {
+    COUNT, VIEWCOUNT, LIKECOUNT, SHARECOUNT
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/StatisticsGetRequest.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/StatisticsGetRequest.java
@@ -1,0 +1,53 @@
+package com.wanted.teamr.snsfeedintegration.dto;
+
+import com.wanted.teamr.snsfeedintegration.domain.StatisticsType;
+import com.wanted.teamr.snsfeedintegration.domain.StatisticsValue;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StatisticsGetRequest {
+
+    private String hashtag;
+    private final StatisticsType type;
+    private LocalDateTime start;
+    private LocalDateTime end;
+    private StatisticsValue value;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private StatisticsGetRequest(String hashtag, StatisticsType type, LocalDateTime start, LocalDateTime end, StatisticsValue value) {
+        this.hashtag = hashtag;
+        this.type = type;
+        this.start = start;
+        this.end = end;
+        this.value = value;
+    }
+
+    public static StatisticsGetRequest of(String hashtag, StatisticsType type, LocalDateTime start, LocalDateTime end, StatisticsValue value) {
+        return StatisticsGetRequest.builder()
+                .hashtag(hashtag)
+                .type(type)
+                .start(start)
+                .end(end)
+                .value(value)
+                .build();
+    }
+
+    public void setHashtag(String hashtag) {
+        this.hashtag = hashtag;
+    }
+
+    public void setStart(LocalDateTime start) {
+        this.start = start;
+    }
+
+    public void setEnd(LocalDateTime end) {
+        this.end = end;
+    }
+
+    public void setValue(StatisticsValue statisticsValue) {
+        this.value = statisticsValue;
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/StatisticsGetRequest.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/StatisticsGetRequest.java
@@ -6,14 +6,21 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 public class StatisticsGetRequest {
 
     private String hashtag;
+
     private final StatisticsType type;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime start;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime end;
+
     private StatisticsValue value;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/StatisticsGetResponse.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/StatisticsGetResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.teamr.snsfeedintegration.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StatisticsGetResponse {
+
+    private final String statisticsAt;
+    private final Long count;
+
+    @Builder
+    public StatisticsGetResponse(String statisticsAt, Long count) {
+        this.statisticsAt = statisticsAt;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -20,8 +20,7 @@ public enum ErrorCode implements ErrorCodeType {
     NOT_FOUND_ERROR_CODE("대응하는 에러코드가 존재하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     STATISTICS_HASHTAG_NOT_FOUND("존재하지 않는 해시태그입니다.", HttpStatus.NOT_FOUND),
-    STATISTICS_PERIOD_INVALID("잘못된 통계 기간입니다.", HttpStatus.BAD_REQUEST),
-    STATISTICS_STATISTICSVALUE_NOT_FOUND("존재하지 않는 통계값입니다.", HttpStatus.BAD_REQUEST)
+    STATISTICS_PERIOD_INVALID("잘못된 통계 기간입니다.", HttpStatus.BAD_REQUEST)
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -20,7 +20,6 @@ public enum ErrorCode implements ErrorCodeType {
     NOT_FOUND_ERROR_CODE("대응하는 에러코드가 존재하지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     STATISTICS_HASHTAG_NOT_FOUND("존재하지 않는 해시태그입니다.", HttpStatus.NOT_FOUND),
-    STATISTICS_PERIOD_MAX_OVER("최대 통계 기간을 초과하였습니다.", HttpStatus.BAD_REQUEST),
     STATISTICS_PERIOD_INVALID("잘못된 통계 기간입니다.", HttpStatus.BAD_REQUEST),
     STATISTICS_STATISTICSVALUE_NOT_FOUND("존재하지 않는 통계값입니다.", HttpStatus.BAD_REQUEST)
     ;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -8,6 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     DUPLICATE_ACCOUNT_NAME_ERROR("이미 같은 이름의 계정이 존재합니다", HttpStatus.BAD_REQUEST),
+    STATISTICS_HASHTAG_NOT_FOUND("존재하지 않는 해시태그입니다.", HttpStatus.NOT_FOUND),
+    STATISTICS_PERIOD_MAX_OVER("최대 통계 기간을 초과하였습니다.", HttpStatus.BAD_REQUEST),
+    STATISTICS_PERIOD_INVALID("잘못된 통계 기간입니다.", HttpStatus.BAD_REQUEST),
+    STATISTICS_STATISTICSVALUE_NOT_FOUND("존재하지 않는 통계값입니다.", HttpStatus.BAD_REQUEST)
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/RequestBodyErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/RequestBodyErrorCode.java
@@ -12,6 +12,11 @@ public enum RequestBodyErrorCode implements ErrorCodeType {
     EMAIL_BLANK("이메일은 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.email"),
     PASSWORD_BLANK("비밀번호는 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.password"),
     EMAIL_INVALID_FORMAT("이메일 형식이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "Email.email"),
+    
+    STATISTICS_STATISTICSTYPE_INVALID("통계 유형이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "typeMismatch.type"),
+    STATISTICS_START_INVALID("통계 시작일시 형식이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "typeMismatch.start"),
+    STATISTICS_END_INVALID("통계 종료일시 형식이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "typeMismatch.end"),
+    STATISTICS_STATISTICSVALUE_INVALID("통계 값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "typeMismatch.value"),
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepository.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepository.java
@@ -1,0 +1,10 @@
+package com.wanted.teamr.snsfeedintegration.repository;
+
+import com.wanted.teamr.snsfeedintegration.domain.PostHashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long>, PostHashtagRepositoryCustom {
+
+    List<PostHashtag> findByHashtag(String hashtag);
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryCustom.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.wanted.teamr.snsfeedintegration.repository;
+
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetRequest;
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetResponse;
+import java.util.List;
+
+public interface PostHashtagRepositoryCustom {
+
+    List<StatisticsGetResponse> getCountByCreatedAt(StatisticsGetRequest request);
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryImpl.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.wanted.teamr.snsfeedintegration.repository;
+
+import static com.wanted.teamr.snsfeedintegration.domain.QPost.post;
+import static com.wanted.teamr.snsfeedintegration.domain.QPostHashtag.postHashtag;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.*;
+import static com.wanted.teamr.snsfeedintegration.exception.ErrorCode.*;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.teamr.snsfeedintegration.domain.StatisticsType;
+import com.wanted.teamr.snsfeedintegration.domain.StatisticsValue;
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetRequest;
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetResponse;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PostHashtagRepositoryImpl implements PostHashtagRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<StatisticsGetResponse> getCountByCreatedAt(StatisticsGetRequest request) {
+        String datetimeFormat = "%Y-%m-%d";
+        if (StatisticsType.HOUR == request.getType()) {
+            datetimeFormat += " %H";
+        }
+
+        StringTemplate formattedDate = Expressions.stringTemplate(
+                "date_format({0}, {1})",
+                post.createdAt,
+                datetimeFormat
+        );
+
+        return jpaQueryFactory.
+                select(Projections.constructor(StatisticsGetResponse.class,
+                        formattedDate.as("statisticsAt"),
+                        countOrSumByStatisticsValue(request.getValue()).as("count"))
+                )
+                .from(postHashtag)
+                .join(postHashtag.post, post)
+                .where(
+                        postHashtag.hashtag.eq(request.getHashtag()),
+                        post.createdAt.goe(request.getStart()),
+                        post.createdAt.loe(request.getEnd())
+                )
+                .groupBy(formattedDate)
+                .orderBy(formattedDate.asc())
+                .fetch();
+    }
+
+    private NumberExpression<Long> countOrSumByStatisticsValue(StatisticsValue statisticsValue) {
+        if (COUNT == statisticsValue) {
+            return post.count();
+        } else if (LIKECOUNT == statisticsValue) {
+            return post.likeCount.sum();
+        } else if (SHARECOUNT == statisticsValue) {
+            return post.shareCount.sum();
+        } else if (VIEWCOUNT == statisticsValue) {
+            return post.viewCount.sum();
+        } else {
+            throw new CustomException(STATISTICS_STATISTICSVALUE_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryImpl.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.wanted.teamr.snsfeedintegration.repository;
 import static com.wanted.teamr.snsfeedintegration.domain.QPost.post;
 import static com.wanted.teamr.snsfeedintegration.domain.QPostHashtag.postHashtag;
 import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.*;
-import static com.wanted.teamr.snsfeedintegration.exception.ErrorCode.*;
+import static com.wanted.teamr.snsfeedintegration.exception.RequestBodyErrorCode.*;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
@@ -63,7 +63,7 @@ public class PostHashtagRepositoryImpl implements PostHashtagRepositoryCustom {
         } else if (VIEWCOUNT == statisticsValue) {
             return post.viewCount.sum();
         } else {
-            throw new CustomException(STATISTICS_STATISTICSVALUE_NOT_FOUND);
+            throw new CustomException(STATISTICS_STATISTICSVALUE_INVALID);
         }
     }
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryImpl.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostHashtagRepositoryImpl.java
@@ -27,7 +27,7 @@ public class PostHashtagRepositoryImpl implements PostHashtagRepositoryCustom {
     public List<StatisticsGetResponse> getCountByCreatedAt(StatisticsGetRequest request) {
         String datetimeFormat = "%Y-%m-%d";
         if (StatisticsType.HOUR == request.getType()) {
-            datetimeFormat += " %H";
+            datetimeFormat += "T%H";
         }
 
         StringTemplate formattedDate = Expressions.stringTemplate(

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/StatisticsService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/StatisticsService.java
@@ -1,0 +1,112 @@
+package com.wanted.teamr.snsfeedintegration.service;
+
+import static com.wanted.teamr.snsfeedintegration.exception.ErrorCode.*;
+
+import com.wanted.teamr.snsfeedintegration.domain.PostHashtag;
+import com.wanted.teamr.snsfeedintegration.domain.StatisticsType;
+import com.wanted.teamr.snsfeedintegration.domain.StatisticsValue;
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetRequest;
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetResponse;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import com.wanted.teamr.snsfeedintegration.repository.PostHashtagRepository;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+    private static final long STATISTICS_MAX_DAILY_PERIOD = 30;
+    private static final long STATISTICS_MAX_HOURLY_PERIOD = 7;
+
+    private final PostHashtagRepository postHashtagRepository;
+
+    @Transactional(readOnly = true)
+    public List<StatisticsGetResponse> getStatistics(StatisticsGetRequest statisticsGetRequest, String memberAccountName) {
+        validateStatisticsOptions(statisticsGetRequest, memberAccountName);
+
+        return postHashtagRepository.getCountByCreatedAt(statisticsGetRequest);
+    }
+
+    private void validateStatisticsOptions(StatisticsGetRequest statisticsGetRequest, String memberAccountName) {
+        validateHashtag(statisticsGetRequest, memberAccountName);
+        validateStartAndEnd(statisticsGetRequest);
+        validateValue(statisticsGetRequest);
+    }
+
+    private void validateHashtag(StatisticsGetRequest statisticsGetRequest, String memberAccountName) {
+        setDefaultHashtag(statisticsGetRequest, memberAccountName);
+        findPostHashtagByHashtag(statisticsGetRequest);
+    }
+
+    private void setDefaultHashtag(StatisticsGetRequest statisticsGetRequest, String memberAccountName) {
+        if (!StringUtils.hasText(statisticsGetRequest.getHashtag())) {
+            statisticsGetRequest.setHashtag(memberAccountName);
+        }
+    }
+
+    private void findPostHashtagByHashtag(StatisticsGetRequest statisticsGetRequest) {
+        List<PostHashtag> postHashtags = postHashtagRepository.findByHashtag(statisticsGetRequest.getHashtag());
+        if (postHashtags.isEmpty()) {
+            throw new CustomException(STATISTICS_HASHTAG_NOT_FOUND);
+        }
+    }
+
+    private void validateStartAndEnd(StatisticsGetRequest statisticsGetRequest) {
+        setDefaultStartAndEnd(statisticsGetRequest);
+        if (StatisticsType.DATE == statisticsGetRequest.getType()) {
+            validatePeriod(statisticsGetRequest, STATISTICS_MAX_DAILY_PERIOD);
+        }
+        if (StatisticsType.HOUR == statisticsGetRequest.getType()) {
+            validatePeriod(statisticsGetRequest, STATISTICS_MAX_HOURLY_PERIOD);
+        }
+    }
+
+    private void setDefaultStartAndEnd(StatisticsGetRequest statisticsGetRequest) {
+        LocalDateTime start = statisticsGetRequest.getStart();
+        LocalDateTime end = statisticsGetRequest.getEnd();
+
+        LocalDateTime now = LocalDateTime.now();
+        if (start == null) {
+            start = now.minusDays(STATISTICS_MAX_HOURLY_PERIOD);
+        }
+        if (end == null) {
+            end = now;
+        }
+
+        if (StatisticsType.DATE == statisticsGetRequest.getType()) {
+            start = start.with(LocalTime.MIN);
+            end = end.with(LocalTime.MIN);
+        }
+
+        statisticsGetRequest.setStart(start);
+        statisticsGetRequest.setEnd(end);
+    }
+
+    private void validatePeriod(StatisticsGetRequest statisticsGetRequest, Long maxPeriod) {
+        LocalDateTime start = statisticsGetRequest.getStart();
+        LocalDateTime end = statisticsGetRequest.getEnd();
+
+        if (start.isAfter(end)) {
+            throw new CustomException(STATISTICS_PERIOD_INVALID);
+        }
+
+        LocalDateTime limitDateTime = end.minusDays(maxPeriod);
+        if (start.isBefore(limitDateTime) || start.isEqual(limitDateTime)) {
+            throw new CustomException(STATISTICS_PERIOD_MAX_OVER);
+        }
+    }
+
+    private void validateValue(StatisticsGetRequest statisticsGetRequest) {
+        if (statisticsGetRequest.getValue() == null) {
+            statisticsGetRequest.setValue(StatisticsValue.COUNT);
+        }
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/StatisticsService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/StatisticsService.java
@@ -13,12 +13,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StatisticsService {

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/StatisticsService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/StatisticsService.java
@@ -100,7 +100,7 @@ public class StatisticsService {
 
         LocalDateTime limitDateTime = end.minusDays(maxPeriod);
         if (start.isBefore(limitDateTime) || start.isEqual(limitDateTime)) {
-            throw new CustomException(STATISTICS_PERIOD_MAX_OVER);
+            throw new CustomException(STATISTICS_PERIOD_INVALID);
         }
     }
 

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsControllerTest.java
@@ -1,17 +1,14 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.DATE;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.HOUR;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.COUNT;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.LIKECOUNT;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.SHARECOUNT;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.VIEWCOUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.*;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.*;
+import static com.wanted.teamr.snsfeedintegration.exception.ErrorCode.*;
+import static com.wanted.teamr.snsfeedintegration.exception.RequestBodyErrorCode.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -185,8 +182,8 @@ class StatisticsControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_HASHTAG_NOT_FOUND.name()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_HASHTAG_NOT_FOUND.getMessage()));
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_HASHTAG_NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_HASHTAG_NOT_FOUND.getMessage()));
     }
 
     @Test
@@ -200,8 +197,8 @@ class StatisticsControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_PERIOD_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_PERIOD_INVALID.getMessage()));
     }
 
     @Test
@@ -215,8 +212,8 @@ class StatisticsControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_PERIOD_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_PERIOD_INVALID.getMessage()));
     }
 
     @Test
@@ -231,8 +228,8 @@ class StatisticsControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_PERIOD_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_PERIOD_INVALID.getMessage()));
     }
 
     @Test
@@ -247,7 +244,74 @@ class StatisticsControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_PERIOD_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_PERIOD_INVALID.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("유효하지 않은 통계유형으로 통계를 조회할 수 없다.")
+    void getStatistics_invalidType() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", "TIME")
+                        .param("start", "2023-01-01T00:00:00")
+                        .param("end", "2023-01-08T23:59:59")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_STATISTICSTYPE_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_STATISTICSTYPE_INVALID.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("유효하지 않은 통계값으로 통계를 조회할 수 없다.")
+    void getStatistics_invalidValue() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023-01-01T00:00:00")
+                        .param("end", "2023-01-08T23:59:59")
+                        .param("value", "TEST")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_STATISTICSVALUE_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_STATISTICSVALUE_INVALID.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("유효하지 않은 통계 시작일시로 통계를 조회할 수 없다.")
+    void getStatistics_invalidStart() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023.01.01T00:00:00")
+                        .param("end", "2023-01-08T23:59:59")
+                        .param("value", "TEST")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_START_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_START_INVALID.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("유효하지 않은 통계 종료일시로 통계를 조회할 수 없다.")
+    void getStatistics_invalidEnd() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023-01-01T00:00:00")
+                        .param("end", "2023.01.08T23:59:59")
+                        .param("value", "TEST")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(STATISTICS_END_INVALID.name()))
+                .andExpect(jsonPath("$.message").value(STATISTICS_END_INVALID.getMessage()));
     }
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsControllerTest.java
@@ -1,0 +1,253 @@
+package com.wanted.teamr.snsfeedintegration.controller;
+
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.DATE;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.HOUR;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.COUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.LIKECOUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.SHARECOUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.VIEWCOUNT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Sql("/db/statistics.sql")
+@AutoConfigureMockMvc
+@SpringBootTest
+class StatisticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser
+    @DisplayName("특정 해시태그로 통계를 조회할 수 있다.")
+    void getStatistics_hashtag() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("hashtag", "hashtag1")
+                        .param("type", DATE.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-30T00:00:00")
+                        .param("value", COUNT.name())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].statisticsAt").value("2023-10-01"))
+                .andExpect(jsonPath("$[0].count").value(2))
+                .andExpect(jsonPath("$[1].statisticsAt").value("2023-10-15"))
+                .andExpect(jsonPath("$[1].count").value(1));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("일자별 count 통계를 조회할 수 있다.")
+    void getStatistics_daily_count() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-30T00:00:00")
+                        .param("value", COUNT.name())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].statisticsAt").value("2023-10-01"))
+                .andExpect(jsonPath("$[0].count").value(3))
+                .andExpect(jsonPath("$[1].statisticsAt").value("2023-10-20"))
+                .andExpect(jsonPath("$[1].count").value(1));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("일자별 viewCount 통계를 조회할 수 있다.")
+    void getStatistics_daily_viewCount() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-30T00:00:00")
+                        .param("value", VIEWCOUNT.name())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].statisticsAt").value("2023-10-01"))
+                .andExpect(jsonPath("$[0].count").value(450))
+                .andExpect(jsonPath("$[1].statisticsAt").value("2023-10-20"))
+                .andExpect(jsonPath("$[1].count").value(650));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("일자별 likeCount 통계를 조회할 수 있다.")
+    void getStatistics_daily_likeCount() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-30T00:00:00")
+                        .param("value", LIKECOUNT.name())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].statisticsAt").value("2023-10-01"))
+                .andExpect(jsonPath("$[0].count").value(45))
+                .andExpect(jsonPath("$[1].statisticsAt").value("2023-10-20"))
+                .andExpect(jsonPath("$[1].count").value(65));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("일자별 shareCount 통계를 조회할 수 있다.")
+    void getStatistics_daily_shareCount() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-30T00:00:00")
+                        .param("value", SHARECOUNT.name())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].statisticsAt").value("2023-10-01"))
+                .andExpect(jsonPath("$[0].count").value(22))
+                .andExpect(jsonPath("$[1].statisticsAt").value("2023-10-20"))
+                .andExpect(jsonPath("$[1].count").value(32));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("시간별 count 통계를 조회할 수 있다.")
+    void getStatistics_hourly_count() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", HOUR.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-07T23:59:59")
+                        .param("value", COUNT.name())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].statisticsAt").value("2023-10-01T12"))
+                .andExpect(jsonPath("$[0].count").value(1))
+                .andExpect(jsonPath("$[1].statisticsAt").value("2023-10-01T13"))
+                .andExpect(jsonPath("$[1].count").value(1))
+                .andExpect(jsonPath("$[2].statisticsAt").value("2023-10-01T14"))
+                .andExpect(jsonPath("$[2].count").value(1));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("통계값 없이 통계를 조회할 수 있다.")
+    void getStatistics_noValue() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("hashtag", "hashtag1")
+                        .param("type", DATE.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-30T23:59:59")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].statisticsAt").value("2023-10-01"))
+                .andExpect(jsonPath("$[0].count").value(2))
+                .andExpect(jsonPath("$[1].statisticsAt").value("2023-10-15"))
+                .andExpect(jsonPath("$[1].count").value(1));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("잘못된 해시태그로 통계를 조회할 수 없다.")
+    void getStatistics_invalidHashtag() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("hashtag", "invalid")
+                        .param("type", DATE.name())
+                        .param("start", "2023-10-01T00:00:00")
+                        .param("end", "2023-10-30T23:59:59")
+                )
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_HASHTAG_NOT_FOUND.name()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_HASHTAG_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("start 미입력 시 조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_start() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("end", "2100-01-01T00:00:00")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("end 미입력 시 조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_end() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2020-01-01T00:00:00")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("조회 기간을 초과하면 일자별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_daily() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", DATE.name())
+                        .param("start", "2023-01-01T00:00:00")
+                        .param("end", "2023-01-31T23:59:59")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_hourly() throws Exception {
+        //given, when, then
+        mockMvc.perform(get("/api/statistics")
+                        .param("type", HOUR.name())
+                        .param("start", "2023-01-01T00:00:00")
+                        .param("end", "2023-01-08T23:59:59")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.name()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.STATISTICS_PERIOD_MAX_OVER.getMessage()));
+    }
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/StatisticsControllerTest.java
@@ -14,11 +14,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @Sql("/db/statistics.sql")
+@Transactional
 @AutoConfigureMockMvc
 @SpringBootTest
 class StatisticsControllerTest {
@@ -27,7 +29,7 @@ class StatisticsControllerTest {
     private MockMvc mockMvc;
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("특정 해시태그로 통계를 조회할 수 있다.")
     void getStatistics_hashtag() throws Exception {
         //given, when, then
@@ -48,7 +50,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("일자별 count 통계를 조회할 수 있다.")
     void getStatistics_daily_count() throws Exception {
         //given, when, then
@@ -68,7 +70,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("일자별 viewCount 통계를 조회할 수 있다.")
     void getStatistics_daily_viewCount() throws Exception {
         //given, when, then
@@ -88,7 +90,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("일자별 likeCount 통계를 조회할 수 있다.")
     void getStatistics_daily_likeCount() throws Exception {
         //given, when, then
@@ -108,7 +110,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("일자별 shareCount 통계를 조회할 수 있다.")
     void getStatistics_daily_shareCount() throws Exception {
         //given, when, then
@@ -128,7 +130,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("시간별 count 통계를 조회할 수 있다.")
     void getStatistics_hourly_count() throws Exception {
         //given, when, then
@@ -150,7 +152,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("통계값 없이 통계를 조회할 수 있다.")
     void getStatistics_noValue() throws Exception {
         //given, when, then
@@ -170,7 +172,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("잘못된 해시태그로 통계를 조회할 수 없다.")
     void getStatistics_invalidHashtag() throws Exception {
         //given, when, then
@@ -187,7 +189,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("start 미입력 시 조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
     void getStatistics_invalidPeriod_start() throws Exception {
         //given, when, then
@@ -202,7 +204,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("end 미입력 시 조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
     void getStatistics_invalidPeriod_end() throws Exception {
         //given, when, then
@@ -217,7 +219,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("조회 기간을 초과하면 일자별 count 통계를 조회할 수 없다.")
     void getStatistics_invalidPeriod_daily() throws Exception {
         //given, when, then
@@ -233,7 +235,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
     void getStatistics_invalidPeriod_hourly() throws Exception {
         //given, when, then
@@ -249,7 +251,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("유효하지 않은 통계유형으로 통계를 조회할 수 없다.")
     void getStatistics_invalidType() throws Exception {
         //given, when, then
@@ -265,7 +267,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("유효하지 않은 통계값으로 통계를 조회할 수 없다.")
     void getStatistics_invalidValue() throws Exception {
         //given, when, then
@@ -282,7 +284,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("유효하지 않은 통계 시작일시로 통계를 조회할 수 없다.")
     void getStatistics_invalidStart() throws Exception {
         //given, when, then
@@ -299,7 +301,7 @@ class StatisticsControllerTest {
     }
 
     @Test
-    @WithMockUser
+    @WithUserDetails(value = "member1")
     @DisplayName("유효하지 않은 통계 종료일시로 통계를 조회할 수 없다.")
     void getStatistics_invalidEnd() throws Exception {
         //given, when, then

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
@@ -1,0 +1,282 @@
+package com.wanted.teamr.snsfeedintegration.service;
+
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.DATE;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.HOUR;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.COUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.LIKECOUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.SHARECOUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.VIEWCOUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetRequest;
+import com.wanted.teamr.snsfeedintegration.dto.StatisticsGetResponse;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest
+@Sql("/db/statistics.sql")
+class StatisticsServiceTest {
+
+    private final String memberAccountName = "member1";
+
+    @Autowired
+    private StatisticsService statisticsService;
+
+    @Test
+    @DisplayName("특정 해시태그로 통계를 조회할 수 있다.")
+    void getStatistics_hashtag() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                "hashtag1",
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 30, 23, 59, 59),
+                COUNT
+        );
+
+        //when
+        List<StatisticsGetResponse> responses = statisticsService.getStatistics(request, memberAccountName);
+
+        //then
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01");
+        assertThat(responses.get(0).getCount()).isEqualTo(2);
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-15");
+        assertThat(responses.get(1).getCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("일자별 count 통계를 조회할 수 있다.")
+    void getStatistics_daily_count() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 30, 23, 59, 59),
+                COUNT
+        );
+
+        //when
+        List<StatisticsGetResponse> responses = statisticsService.getStatistics(request, memberAccountName);
+
+        //then
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01");
+        assertThat(responses.get(0).getCount()).isEqualTo(3);
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-20");
+        assertThat(responses.get(1).getCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("일자별 viewCount 통계를 조회할 수 있다.")
+    void getStatistics_daily_viewCount() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 30, 23, 59, 59),
+                VIEWCOUNT
+        );
+
+        //when
+        List<StatisticsGetResponse> responses = statisticsService.getStatistics(request, memberAccountName);
+
+        //then
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01");
+        assertThat(responses.get(0).getCount()).isEqualTo(450);
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-20");
+        assertThat(responses.get(1).getCount()).isEqualTo(650);
+    }
+
+    @Test
+    @DisplayName("일자별 viewCount 통계를 조회할 수 있다.")
+    void getStatistics_daily_likeCount() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 30, 23, 59, 59),
+                LIKECOUNT
+        );
+
+        //when
+        List<StatisticsGetResponse> responses = statisticsService.getStatistics(request, memberAccountName);
+
+        //then
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01");
+        assertThat(responses.get(0).getCount()).isEqualTo(45);
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-20");
+        assertThat(responses.get(1).getCount()).isEqualTo(65);
+    }
+
+    @Test
+    @DisplayName("일자별 viewCount 통계를 조회할 수 있다.")
+    void getStatistics_daily_shareCount() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 30, 23, 59, 59),
+                SHARECOUNT
+        );
+
+        //when
+        List<StatisticsGetResponse> responses = statisticsService.getStatistics(request, memberAccountName);
+
+        //then
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01");
+        assertThat(responses.get(0).getCount()).isEqualTo(22);
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-20");
+        assertThat(responses.get(1).getCount()).isEqualTo(32);
+    }
+
+    @Test
+    @DisplayName("시간별 count 통계를 조회할 수 있다.")
+    void getStatistics_hourly_count() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                HOUR,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 7, 23, 59, 59),
+                COUNT
+        );
+
+        //when
+        List<StatisticsGetResponse> responses = statisticsService.getStatistics(request, memberAccountName);
+
+        //then
+        assertThat(responses.size()).isEqualTo(3);
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01 12");
+        assertThat(responses.get(0).getCount()).isEqualTo(1);
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-01 13");
+        assertThat(responses.get(1).getCount()).isEqualTo(1);
+        assertThat(responses.get(2).getStatisticsAt()).isEqualTo("2023-10-01 14");
+        assertThat(responses.get(2).getCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("통계값 없이 통계를 조회할 수 있다.")
+    void getStatistics_noValue() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                "hashtag1",
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 30, 23, 59, 59),
+                null
+        );
+
+        //when
+        List<StatisticsGetResponse> responses = statisticsService.getStatistics(request, memberAccountName);
+        for (StatisticsGetResponse respons : responses) {
+            System.out.println("respons = " + respons);
+        }
+
+        //then
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01");
+        assertThat(responses.get(0).getCount()).isEqualTo(2);
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-15");
+        assertThat(responses.get(1).getCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("잘못된 해시태그로 통계를 조회할 수 없다.")
+    void getStatistics_invalidHashtag() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                "invalid",
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 7, 23, 59, 59),
+                COUNT
+        );
+
+        //when then
+        assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("start 미입력 시 조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_start() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                HOUR,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                null,
+                COUNT
+        );
+
+        //when then
+        assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("end 미입력 시 조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_end() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                HOUR,
+                null,
+                LocalDateTime.of(2023, 10, 7, 23, 59, 59),
+                COUNT
+        );
+
+        //when then
+        assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("조회 기간을 초과하면 일자별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_daily() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                DATE,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 31, 0, 0, 0),
+                COUNT
+        );
+
+        //when then
+        assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("조회 기간을 초과하면 시간별 count 통계를 조회할 수 없다.")
+    void getStatistics_invalidPeriod_hourly() {
+        //given
+        StatisticsGetRequest request = StatisticsGetRequest.of(
+                null,
+                HOUR,
+                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2023, 10, 8, 23, 59, 59),
+                COUNT
+        );
+
+        //when then
+        assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
+                .isInstanceOf(CustomException.class);
+    }
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
@@ -1,11 +1,8 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.DATE;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.HOUR;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.COUNT;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.LIKECOUNT;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.SHARECOUNT;
-import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.VIEWCOUNT;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsType.*;
+import static com.wanted.teamr.snsfeedintegration.domain.StatisticsValue.*;
+import static com.wanted.teamr.snsfeedintegration.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -209,7 +206,8 @@ class StatisticsServiceTest {
 
         //when then
         assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
-                .isInstanceOf(CustomException.class);
+                .isInstanceOf(CustomException.class)
+                .hasMessage(STATISTICS_HASHTAG_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -226,7 +224,8 @@ class StatisticsServiceTest {
 
         //when then
         assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
-                .isInstanceOf(CustomException.class);
+                .isInstanceOf(CustomException.class)
+                .hasMessage(STATISTICS_PERIOD_INVALID.getMessage());
     }
 
     @Test
@@ -243,7 +242,8 @@ class StatisticsServiceTest {
 
         //when then
         assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
-                .isInstanceOf(CustomException.class);
+                .isInstanceOf(CustomException.class)
+                .hasMessage(STATISTICS_PERIOD_INVALID.getMessage());
     }
 
     @Test
@@ -260,7 +260,8 @@ class StatisticsServiceTest {
 
         //when then
         assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
-                .isInstanceOf(CustomException.class);
+                .isInstanceOf(CustomException.class)
+                .hasMessage(STATISTICS_PERIOD_INVALID.getMessage());
     }
 
     @Test
@@ -277,6 +278,7 @@ class StatisticsServiceTest {
 
         //when then
         assertThatThrownBy(() -> statisticsService.getStatistics(request, memberAccountName))
-                .isInstanceOf(CustomException.class);
+                .isInstanceOf(CustomException.class)
+                .hasMessage(STATISTICS_PERIOD_INVALID.getMessage());
     }
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
@@ -16,9 +16,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
 @Sql("/db/statistics.sql")
+@Transactional
+@SpringBootTest
 class StatisticsServiceTest {
 
     private final String memberAccountName = "member1";

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/StatisticsServiceTest.java
@@ -99,7 +99,7 @@ class StatisticsServiceTest {
     }
 
     @Test
-    @DisplayName("일자별 viewCount 통계를 조회할 수 있다.")
+    @DisplayName("일자별 likeCount 통계를 조회할 수 있다.")
     void getStatistics_daily_likeCount() {
         //given
         StatisticsGetRequest request = StatisticsGetRequest.of(
@@ -122,7 +122,7 @@ class StatisticsServiceTest {
     }
 
     @Test
-    @DisplayName("일자별 viewCount 통계를 조회할 수 있다.")
+    @DisplayName("일자별 shareCount 통계를 조회할 수 있다.")
     void getStatistics_daily_shareCount() {
         //given
         StatisticsGetRequest request = StatisticsGetRequest.of(
@@ -161,11 +161,11 @@ class StatisticsServiceTest {
 
         //then
         assertThat(responses.size()).isEqualTo(3);
-        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01 12");
+        assertThat(responses.get(0).getStatisticsAt()).isEqualTo("2023-10-01T12");
         assertThat(responses.get(0).getCount()).isEqualTo(1);
-        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-01 13");
+        assertThat(responses.get(1).getStatisticsAt()).isEqualTo("2023-10-01T13");
         assertThat(responses.get(1).getCount()).isEqualTo(1);
-        assertThat(responses.get(2).getStatisticsAt()).isEqualTo("2023-10-01 14");
+        assertThat(responses.get(2).getStatisticsAt()).isEqualTo("2023-10-01T14");
         assertThat(responses.get(2).getCount()).isEqualTo(1);
     }
 
@@ -219,7 +219,7 @@ class StatisticsServiceTest {
         StatisticsGetRequest request = StatisticsGetRequest.of(
                 null,
                 HOUR,
-                LocalDateTime.of(2023, 10, 1, 0, 0, 0),
+                LocalDateTime.of(2100, 1, 1, 0, 0, 0),
                 null,
                 COUNT
         );

--- a/src/test/resources/db/statistics.sql
+++ b/src/test/resources/db/statistics.sql
@@ -3,6 +3,9 @@ TRUNCATE TABLE post_hashtag;
 TRUNCATE TABLE post;
 set FOREIGN_KEY_CHECKS = 1;
 
+INSERT INTO member(account_name, email, password, approval_code, is_approved, authority)
+values ('member1', 'test@test.com', '1234', 'test', 1, 'ROLE_USER');
+
 INSERT INTO post(content_id, type, title, content, view_count, like_count, share_count, created_at)
 VALUES ('content1', 'FACEBOOK', 'Title 1', 'This is content 1', 100, 10, 5, '2023-10-01 12:01:01'),
        ('content2', 'TWITTER', 'Title 2', 'This is content 2', 150, 15, 7, '2023-10-01 13:02:02'),

--- a/src/test/resources/db/statistics.sql
+++ b/src/test/resources/db/statistics.sql
@@ -1,0 +1,54 @@
+set FOREIGN_KEY_CHECKS = 0;
+TRUNCATE TABLE post_hashtag;
+TRUNCATE TABLE post;
+set FOREIGN_KEY_CHECKS = 1;
+
+INSERT INTO post(content_id, type, title, content, view_count, like_count, share_count, created_at)
+VALUES ('content1', 'FACEBOOK', 'Title 1', 'This is content 1', 100, 10, 5, '2023-10-01 12:01:01'),
+       ('content2', 'TWITTER', 'Title 2', 'This is content 2', 150, 15, 7, '2023-10-01 13:02:02'),
+       ('content3', 'INSTAGRAM', 'Title 3', 'This is content 3', 200, 20, 10, '2023-10-01 14:03:03'),
+       ('content4', 'THREADS', 'Title 4', 'This is content 4', 250, 25, 12, '2023-10-01 15:04:04'),
+       ('content5', 'FACEBOOK', 'Title 5', 'This is content 5', 300, 30, 15, '2023-10-01 16:05:05'),
+       ('content6', 'TWITTER', 'Title 6', 'This is content 6', 350, 35, 17, '2023-10-01 17:06:06'),
+       ('content7', 'INSTAGRAM', 'Title 7', 'This is content 7', 400, 40, 20, '2023-10-01 18:07:07'),
+       ('content8', 'THREADS', 'Title 8', 'This is content 8', 450, 45, 22, '2023-10-01 19:08:08'),
+       ('content9', 'FACEBOOK', 'Title 9', 'This is content 9', 500, 50, 25, '2023-10-05 20:09:09'),
+       ('content10', 'TWITTER', 'Title 10', 'This is content 10', 550, 55, 27, '2023-10-10 21:10:10'),
+       ('content11', 'INSTAGRAM', 'Title 11', 'This is content 11', 600, 60, 30, '2023-10-15 22:11:11'),
+       ('content12', 'THREADS', 'Title 12', 'This is content 12', 650, 65, 32, '2023-10-20 23:12:12'),
+       ('content13', 'FACEBOOK', 'Title 13', 'This is content 13', 700, 70, 35, '2023-10-25 00:13:13'),
+       ('content14', 'TWITTER', 'Title 14', 'This is content 14', 750, 75, 37, '2023-10-30 01:14:14'),
+       ('content15', 'INSTAGRAM', 'Title 15', 'This is content 15', 800, 80, 40, '2023-11-01 02:15:15'),
+       ('content16', 'THREADS', 'Title 16', 'This is content 16', 850, 85, 42, '2023-11-05 03:16:16'),
+       ('content17', 'FACEBOOK', 'Title 17', 'This is content 17', 900, 90, 45, '2023-11-10 04:17:17'),
+       ('content18', 'TWITTER', 'Title 18', 'This is content 18', 950, 95, 47, '2023-11-15 05:18:18'),
+       ('content19', 'INSTAGRAM', 'Title 19', 'This is content 19', 1000, 100, 50, '2023-11-20 06:19:19'),
+       ('content20', 'THREADS', 'Title 20', 'This is content 20', 1050, 105, 52, '2023-11-25 07:20:20');
+
+INSERT INTO post_hashtag(post_id, hashtag)
+VALUES (1, 'hashtag1'),
+       (1, 'member1'),
+       (2, 'hashtag2'),
+       (2, 'member1'),
+       (3, 'hashtag3'),
+       (3, 'member1'),
+       (4, 'hashtag4'),
+       (5, 'hashtag5'),
+       (6, 'hashtag1'),
+       (7, 'hashtag2'),
+       (8, 'hashtag3'),
+       (9, 'hashtag4'),
+       (10, 'hashtag5'),
+       (11, 'hashtag1'),
+       (12, 'hashtag2'),
+       (12, 'member1'),
+       (12, 'hashtag2'),
+       (13, 'hashtag3'),
+       (14, 'hashtag4'),
+       (15, 'hashtag5'),
+       (16, 'hashtag1'),
+       (17, 'hashtag2'),
+       (18, 'hashtag3'),
+       (19, 'hashtag4'),
+       (20, 'hashtag5');
+


### PR DESCRIPTION
## 📃 설명

- resolves #14 

## 🔨 작업 내용
1. 특정 해시태그가 설정된 게시물의 일자별/시간별 통계 조회 API 구현
  - 통계유형(StatisticsType): DATE/HOUR
  - 통계값(StatisticsValue): COUNT/VIEWCOUNT/LIKECOUNT/SHARECOUNT
2. QueryDSL 설정 추가

## ⭐⭐⭐ 중요 참고사항
- MySQL에 의존하는 코드가 추가되어, 앞으로 DB는 MySQL로 작업 필요함.

## 💬 기타 사항