### PR TITLE
사용자 가입승인 API 구현 완료 feat #22

### DIFF
--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/MemberController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
+import com.wanted.teamr.snsfeedintegration.dto.MemberApprovalRequest;
 import com.wanted.teamr.snsfeedintegration.dto.MemberJoinRequest;
 import com.wanted.teamr.snsfeedintegration.service.MemberService;
 import com.wanted.teamr.snsfeedintegration.util.PasswordValidator;
@@ -24,6 +25,12 @@ public class MemberController {
     public ResponseEntity<?> join(@Validated(ValidationSequence.class) @RequestBody MemberJoinRequest dto) {
         PasswordValidator.validatePassword(dto);
         memberService.join(dto);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PostMapping("/approve")
+    public ResponseEntity<?> approve(@Validated(ValidationSequence.class) @RequestBody MemberApprovalRequest dto) {
+        memberService.approve(dto);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
@@ -1,6 +1,8 @@
 package com.wanted.teamr.snsfeedintegration.domain;
 
 import com.wanted.teamr.snsfeedintegration.dto.MemberJoinRequest;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -45,6 +47,13 @@ public class Member extends BaseEntity {
                 .approvalCode(approvalCode)
                 .isApproved(false)
                 .build();
+    }
+
+    public void approve() {
+        if (getIsApproved()) {
+            throw new CustomException(ErrorCode.ALREADY_APPROVED);
+        }
+        isApproved = true;
     }
 
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberApprovalRequest.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberApprovalRequest.java
@@ -1,0 +1,29 @@
+package com.wanted.teamr.snsfeedintegration.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MemberApprovalRequest {
+
+    @NotBlank
+    private String accountName;
+    @NotBlank
+    private String password;
+    @NotBlank
+    @Pattern(regexp = "^[0-9A-Za-z]{6}$", groups = Pattern.class)
+    private String approvalCode;
+
+    private MemberApprovalRequest(String accountName, String password, String approvalCode) {
+        this.accountName = accountName;
+        this.password = password;
+        this.approvalCode = approvalCode;
+    }
+
+    public static MemberApprovalRequest of(String accountName, String password, String approvalCode) {
+        return new MemberApprovalRequest(accountName, password, approvalCode);
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberJoinRequest.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberJoinRequest.java
@@ -1,6 +1,5 @@
 package com.wanted.teamr.snsfeedintegration.dto;
 
-import com.wanted.teamr.snsfeedintegration.util.ValidationGroup;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -15,7 +14,7 @@ public class MemberJoinRequest {
 
     @NotBlank
     @Email(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$",
-            groups = ValidationGroup.Email.class)
+            groups = Email.class)
     private String email;
 
     @NotBlank

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode implements ErrorCodeType {
 //    PASSWORD_MOST_USED("통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_ACCOUNT_NAME("이미 같은 이름의 계정이 존재합니다", HttpStatus.BAD_REQUEST),
     ACCOUNT_INFO_WRONG("계정 이름 또는 비밀번호가 틀렸습니다.", HttpStatus.BAD_REQUEST),
+    APPROVAL_CODE_WRONG("승인코드가 틀렸습니다.", HttpStatus.BAD_REQUEST),
 
     POST_NOT_FOUND("게시물이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode implements ErrorCodeType {
     DUPLICATE_ACCOUNT_NAME("이미 같은 이름의 계정이 존재합니다", HttpStatus.BAD_REQUEST),
     ACCOUNT_INFO_WRONG("계정 이름 또는 비밀번호가 틀렸습니다.", HttpStatus.BAD_REQUEST),
     APPROVAL_CODE_WRONG("승인코드가 틀렸습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_APPROVED("이미 가입승인이 완료되었습니다", HttpStatus.BAD_REQUEST),
 
     POST_NOT_FOUND("게시물이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode implements ErrorCodeType {
     PASSWORD_PERSONAL_INFO("다른 개인정보와 유사한 비밀번호는 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
 //    PASSWORD_MOST_USED("통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_ACCOUNT_NAME("이미 같은 이름의 계정이 존재합니다", HttpStatus.BAD_REQUEST),
+    ACCOUNT_INFO_WRONG("계정 이름 또는 비밀번호가 틀렸습니다.", HttpStatus.BAD_REQUEST),
 
     POST_NOT_FOUND("게시물이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/RequestBodyErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/RequestBodyErrorCode.java
@@ -11,6 +11,7 @@ public enum RequestBodyErrorCode implements ErrorCodeType {
     ACCOUNT_NAME_BLANK("계정 이름은 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.accountName"),
     EMAIL_BLANK("이메일은 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.email"),
     PASSWORD_BLANK("비밀번호는 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.password"),
+    APPROVAL_CODE_BLANK("승인코드는 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.approvalCode"),
     EMAIL_INVALID_FORMAT("이메일 형식이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "Email.email"),
     ;
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/RequestBodyErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/RequestBodyErrorCode.java
@@ -13,6 +13,7 @@ public enum RequestBodyErrorCode implements ErrorCodeType {
     PASSWORD_BLANK("비밀번호는 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.password"),
     APPROVAL_CODE_BLANK("승인코드는 공백일 수 없습니다.", HttpStatus.BAD_REQUEST, "NotBlank.approvalCode"),
     EMAIL_INVALID_FORMAT("이메일 형식이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "Email.email"),
+    APPROVAL_CODE_INVALID_FORMAT("승인코드 형식이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "Pattern.approvalCode"),
     ;
 
     private final String message;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/MemberRepository.java
@@ -3,5 +3,9 @@ package com.wanted.teamr.snsfeedintegration.repository;
 import com.wanted.teamr.snsfeedintegration.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByAccountName(String accountName);
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/MemberService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
 import com.wanted.teamr.snsfeedintegration.domain.Member;
+import com.wanted.teamr.snsfeedintegration.dto.MemberApprovalRequest;
 import com.wanted.teamr.snsfeedintegration.dto.MemberJoinRequest;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
@@ -31,4 +32,31 @@ public class MemberService {
             throw new CustomException(ErrorCode.DUPLICATE_ACCOUNT_NAME, e);
         }
     }
+
+    @Transactional
+    public Long approve(MemberApprovalRequest dto) {
+        Member member = getMember(dto);
+        validatePassword(dto, member);
+        validateApprovalCode(dto, member);
+        member.approve();
+        return member.getId();
+    }
+
+    private Member getMember(MemberApprovalRequest dto) {
+        return memberRepository.findByAccountName(dto.getAccountName())
+                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_INFO_WRONG));
+    }
+
+    private void validatePassword(MemberApprovalRequest dto, Member member) {
+        if (!passwordEncoder.matches(dto.getPassword(), member.getPassword())) {
+            throw new CustomException(ErrorCode.ACCOUNT_INFO_WRONG);
+        }
+    }
+
+    private static void validateApprovalCode(MemberApprovalRequest dto, Member member) {
+        if (!dto.getApprovalCode().equals(member.getApprovalCode())) {
+            throw new CustomException(ErrorCode.APPROVAL_CODE_WRONG);
+        }
+    }
+
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/util/ValidationGroup.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/util/ValidationGroup.java
@@ -1,6 +1,0 @@
-package com.wanted.teamr.snsfeedintegration.util;
-
-public interface ValidationGroup {
-    interface NotBlank {}
-    interface Email {}
-}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/util/ValidationSequence.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/util/ValidationSequence.java
@@ -1,8 +1,13 @@
 package com.wanted.teamr.snsfeedintegration.util;
 
 import jakarta.validation.GroupSequence;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.groups.Default;
 
-@GroupSequence({Default.class, ValidationGroup.NotBlank.class, ValidationGroup.Email.class})
+@GroupSequence({
+        Default.class,
+        NotBlank.class,
+        Email.class})
 public interface ValidationSequence {
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/util/ValidationSequence.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/util/ValidationSequence.java
@@ -3,11 +3,13 @@ package com.wanted.teamr.snsfeedintegration.util;
 import jakarta.validation.GroupSequence;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.groups.Default;
 
 @GroupSequence({
         Default.class,
         NotBlank.class,
-        Email.class})
+        Email.class,
+        Pattern.class})
 public interface ValidationSequence {
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("/api/members WebMvc 테스트")
+@DisplayName("/api/members WebMvc")
 @Import(SecurityConfig.class)
 @WebMvcTest(MemberController.class)
 class MemberControllerMockTest {
@@ -43,7 +43,7 @@ class MemberControllerMockTest {
     @Autowired
     private ObjectMapper mapper;
 
-    @DisplayName("사용자 회원가입 WebMvc")
+    @DisplayName("/join 사용자 회원가입 WebMvc")
     @Nested
     class Join {
 
@@ -55,25 +55,25 @@ class MemberControllerMockTest {
                     .willReturn(1L);
         }
 
-        @DisplayName("빈 계정 이름")
+        @DisplayName("[계정 이름] 공백")
         @Test
         void givenBlankAccountName_then400() throws Exception {
             validateRequestBody(BLANK, EMAIL, PASSWORD, RequestBodyErrorCode.ACCOUNT_NAME_BLANK);
         }
 
-        @DisplayName("빈 이메일")
+        @DisplayName("[이메일] 공백")
         @Test
         void givenBlankEmail_then400() throws Exception {
             validateRequestBody(ACCOUNT_NAME, BLANK, PASSWORD, RequestBodyErrorCode.EMAIL_BLANK);
         }
 
-        @DisplayName("빈 비밀번호")
+        @DisplayName("[비밀번호] 공백")
         @Test
         void givenBlankPassword_then400() throws Exception {
             validateRequestBody(ACCOUNT_NAME, EMAIL, BLANK, RequestBodyErrorCode.PASSWORD_BLANK);
         }
 
-        @DisplayName("잘못된 이메일 형식")
+        @DisplayName("[이메일] 잘못된 형식")
         @ValueSource(strings = {"wrong_email@", "@a.com", "aa.com", "a.d@s"})
         @ParameterizedTest
         void givenInvalidEmailFormat_then400(String email) throws Exception {
@@ -133,7 +133,7 @@ class MemberControllerMockTest {
 
     }
 
-    @DisplayName("사용자 가입승인 WebMvc")
+    @DisplayName("/approve 사용자 가입승인 WebMvc")
     @Nested
     class Approve {
 
@@ -145,19 +145,19 @@ class MemberControllerMockTest {
                     .willReturn(1L);
         }
 
-        @DisplayName("빈 계정 이름")
+        @DisplayName("[계정 이름] 공백")
         @Test
         void givenBlankAccountName_then400() throws Exception {
             validateRequestBody(BLANK, PASSWORD, APPROVAL_CODE, RequestBodyErrorCode.ACCOUNT_NAME_BLANK);
         }
 
-        @DisplayName("빈 비밀번호")
+        @DisplayName("[비밀번호] 공백")
         @Test
         void givenBlankPassword_then400() throws Exception {
             validateRequestBody(ACCOUNT_NAME, BLANK, APPROVAL_CODE, RequestBodyErrorCode.PASSWORD_BLANK);
         }
 
-        @DisplayName("빈 승인코드")
+        @DisplayName("[승인코드] 공백")
         @Test
         void givenBlankApprovalCode_then400() throws Exception {
             validateRequestBody(ACCOUNT_NAME, PASSWORD, BLANK, RequestBodyErrorCode.APPROVAL_CODE_BLANK);

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
@@ -128,17 +128,7 @@ class MemberControllerMockTest {
                                          String password,
                                          ErrorCodeType errorCodeType) throws Exception {
             MemberJoinRequest dto = MemberJoinRequest.of(accountName, email, password);
-            String content = mapper.writeValueAsString(dto);
-            String message = errorCodeType.getMessage();
-            mockMvc.perform(post(URI)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(content)
-                    )
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.errorCode").value(errorCodeType.name()))
-                    .andExpect(jsonPath("$.message").value(message))
-                    .andDo(print())
-                    .andReturn();
+            MemberControllerMockTest.this.validateRequestBody(dto, errorCodeType, URI);
         }
 
     }
@@ -178,19 +168,25 @@ class MemberControllerMockTest {
                                          String approvalCode,
                                          ErrorCodeType errorCodeType) throws Exception {
             MemberApprovalRequest dto = MemberApprovalRequest.of(accountName, password, approvalCode);
-            String content = mapper.writeValueAsString(dto);
-            String message = errorCodeType.getMessage();
-            mockMvc.perform(post(URI)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(content)
-                    )
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.errorCode").value(errorCodeType.name()))
-                    .andExpect(jsonPath("$.message").value(message))
-                    .andDo(print())
-                    .andReturn();
+            MemberControllerMockTest.this.validateRequestBody(dto, errorCodeType, URI);
         }
 
+    }
+
+    private void validateRequestBody(Object dto,
+                                     ErrorCodeType errorCodeType,
+                                     String uri) throws Exception {
+        String content = mapper.writeValueAsString(dto);
+        String message = errorCodeType.getMessage();
+        mockMvc.perform(post(uri)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(errorCodeType.name()))
+                .andExpect(jsonPath("$.message").value(message))
+                .andDo(print())
+                .andReturn();
     }
 
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
@@ -163,6 +163,13 @@ class MemberControllerMockTest {
             validateRequestBody(ACCOUNT_NAME, PASSWORD, BLANK, RequestBodyErrorCode.APPROVAL_CODE_BLANK);
         }
 
+        @DisplayName("[승인코드] 유효하지 않은 형식")
+        @ParameterizedTest
+        @ValueSource(strings = {"1235A", "1235AAA", "sd12A&"})
+        void givenInvalidApprovalCodeFormat_then400(String approvalCode) throws Exception {
+            validateRequestBody(ACCOUNT_NAME, PASSWORD, approvalCode, RequestBodyErrorCode.APPROVAL_CODE_INVALID_FORMAT);
+        }
+
         private void validateRequestBody(String accountName,
                                          String password,
                                          String approvalCode,

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerTest.java
@@ -1,8 +1,11 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.teamr.snsfeedintegration.domain.Member;
+import com.wanted.teamr.snsfeedintegration.dto.MemberApprovalRequest;
 import com.wanted.teamr.snsfeedintegration.dto.MemberJoinRequest;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
+import com.wanted.teamr.snsfeedintegration.repository.MemberRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -16,6 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 @DisplayName("/api/members 통합 테스트")
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -27,9 +31,12 @@ class MemberControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper mapper;
+    @Autowired
+    private MemberRepository memberRepository;
 
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @DisplayName("/join 사용자 회원가입")
+    @Order(1)
     @Nested
     class Join {
 
@@ -67,4 +74,55 @@ class MemberControllerTest {
         }
 
     }
+
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @DisplayName("/approve 사용자 가입승인")
+    @Order(2)
+    @Nested
+    class Approve {
+
+        private static final String URI = BASE_URI + "/approve";
+
+        private String approvalCode;
+
+        @BeforeEach
+        void setUp() {
+            Member member = memberRepository.findById(1L).orElseThrow();
+            approvalCode = member.getApprovalCode();
+        }
+
+        @Order(1)
+        @DisplayName("성공")
+        @Test
+        void whenSuccess_then201() throws Exception {
+            MemberApprovalRequest dto = MemberApprovalRequest.of(ACCOUNT_NAME, PASSWORD, approvalCode);
+            String content = mapper.writeValueAsString(dto);
+            mockMvc.perform(post(URI)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(content))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$").doesNotExist())
+                    .andDo(print())
+                    .andReturn();
+        }
+
+        @Order(2)
+        @DisplayName("이미 가입승인 완료")
+        @Test
+        void givenAlreadyApproved_then400() throws Exception {
+            MemberApprovalRequest dto = MemberApprovalRequest.of(ACCOUNT_NAME, PASSWORD, approvalCode);
+            String content = mapper.writeValueAsString(dto);
+            ErrorCode errorCode = ErrorCode.ALREADY_APPROVED;
+            mockMvc.perform(post(URI)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(content))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value(errorCode.name()))
+                    .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
+                    .andDo(print())
+                    .andReturn();
+        }
+
+    }
+
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/TestConstants.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/TestConstants.java
@@ -7,6 +7,7 @@ public interface TestConstants {
     String EMAIL_DOMAIN = "gmail.com";
     String EMAIL = EMAIL_HEAD + "@" + EMAIL_DOMAIN;
     String PASSWORD = "qlalfqjsgh486^^";
+    String APPROVAL_CODE = "a1dYsN";
     String BLANK = "  ";
 
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
@@ -17,8 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
-import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.ACCOUNT_NAME;
-import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.PASSWORD;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -80,6 +79,34 @@ class MemberServiceMockTest {
             Assertions.assertThatThrownBy(() -> sut.approve(dto))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
+        }
+
+        @DisplayName("[승인코드] 불일치")
+        @Test
+        void givenWrongApprovalCode_thenThrowsWithAPPROVAL_CODE_WRONG() {
+            // given
+            Member member = mock(Member.class);
+            given(memberRepository.findByAccountName(anyString()))
+                    .willReturn(Optional.of(member));
+
+            MemberApprovalRequest dto = mock(MemberApprovalRequest.class);
+            given(dto.getAccountName())
+                    .willReturn(ACCOUNT_NAME);
+            given(member.getPassword())
+                    .willReturn(PASSWORD);
+            given(dto.getPassword())
+                    .willReturn(PASSWORD);
+            given(passwordEncoder.matches(dto.getPassword(), member.getPassword()))
+                    .willReturn(true);
+            given(dto.getApprovalCode())
+                    .willReturn("wrongApprovalCode");
+            given(member.getApprovalCode())
+                    .willReturn(APPROVAL_CODE);
+
+            // when, then
+            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.APPROVAL_CODE_WRONG.getMessage());
         }
 
     }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
@@ -1,5 +1,6 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
+import com.wanted.teamr.snsfeedintegration.domain.Member;
 import com.wanted.teamr.snsfeedintegration.dto.MemberApprovalRequest;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
@@ -12,9 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.ACCOUNT_NAME;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.PASSWORD;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -27,6 +31,8 @@ class MemberServiceMockTest {
     private MemberService sut;
     @Mock
     private MemberRepository memberRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @DisplayName("사용자 가입승인 서비스 Mock 테스트")
     @Nested
@@ -43,6 +49,32 @@ class MemberServiceMockTest {
             String wrongAccountName = "wrongAccountName";
             given(dto.getAccountName())
                     .willReturn(wrongAccountName);
+
+            // when, then
+            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
+        }
+
+        @DisplayName("[비밀번호] 불일치")
+        @Test
+        void givenWrongPassword_thenThrowsWithACCOUNT_INFO_WRONG() {
+            // given
+            Member member = mock(Member.class);
+            given(memberRepository.findByAccountName(anyString()))
+                    .willReturn(Optional.of(member));
+
+            MemberApprovalRequest dto = mock(MemberApprovalRequest.class);
+            given(dto.getAccountName())
+                    .willReturn(ACCOUNT_NAME);
+
+            given(member.getPassword())
+                    .willReturn(PASSWORD);
+            given(dto.getPassword())
+                    .willReturn(PASSWORD);
+
+            given(passwordEncoder.matches(dto.getPassword(), member.getPassword()))
+                    .willReturn(false);
 
             // when, then
             Assertions.assertThatThrownBy(() -> sut.approve(dto))

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
@@ -20,8 +20,8 @@ import java.util.Optional;
 import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
 @DisplayName("사용자 서비스 Mock 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -140,6 +140,37 @@ class MemberServiceMockTest {
             // when, then
             Assertions.assertThatThrownBy(() -> sut.approve(dto))
                     .isInstanceOf(CustomException.class);
+        }
+
+        @DisplayName("성공")
+        @Test
+        void whenSuccess_thenMemberApproveCalled() {
+            // given
+            MemberApprovalRequest dto = mock(MemberApprovalRequest.class);
+            Member member = mock(Member.class);
+
+            given(dto.getAccountName())
+                    .willReturn(ACCOUNT_NAME);
+            given(memberRepository.findByAccountName(anyString()))
+                    .willReturn(Optional.of(member));
+
+            given(member.getPassword())
+                    .willReturn(PASSWORD);
+            given(dto.getPassword())
+                    .willReturn(PASSWORD);
+            given(passwordEncoder.matches(dto.getPassword(), member.getPassword()))
+                    .willReturn(true);
+
+            given(dto.getApprovalCode())
+                    .willReturn(APPROVAL_CODE);
+            given(member.getApprovalCode())
+                    .willReturn(APPROVAL_CODE);
+
+            // when, then
+            sut.approve(dto);
+
+            // then
+            then(member).should(times(1)).approve();
         }
 
     }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 @DisplayName("사용자 서비스 Mock 테스트")
@@ -107,6 +108,38 @@ class MemberServiceMockTest {
             Assertions.assertThatThrownBy(() -> sut.approve(dto))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.APPROVAL_CODE_WRONG.getMessage());
+        }
+
+        @DisplayName("이미 가입승인 완료")
+        @Test
+        void givenJoinHaveAlreadyApproved_thenThrowsWithALREADY_APPROVED() {
+            // given
+            MemberApprovalRequest dto = mock(MemberApprovalRequest.class);
+            Member member = mock(Member.class);
+
+            given(dto.getAccountName())
+                    .willReturn(ACCOUNT_NAME);
+            given(memberRepository.findByAccountName(anyString()))
+                    .willReturn(Optional.of(member));
+
+            given(member.getPassword())
+                    .willReturn(PASSWORD);
+            given(dto.getPassword())
+                    .willReturn(PASSWORD);
+            given(passwordEncoder.matches(dto.getPassword(), member.getPassword()))
+                    .willReturn(true);
+
+            given(dto.getApprovalCode())
+                    .willReturn(APPROVAL_CODE);
+            given(member.getApprovalCode())
+                    .willReturn(APPROVAL_CODE);
+
+            doThrow(CustomException.class)
+                    .when(member).approve();
+
+            // when, then
+            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class);
         }
 
     }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceMockTest.java
@@ -1,0 +1,55 @@
+package com.wanted.teamr.snsfeedintegration.service;
+
+import com.wanted.teamr.snsfeedintegration.dto.MemberApprovalRequest;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
+import com.wanted.teamr.snsfeedintegration.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("사용자 서비스 Mock 테스트")
+@ExtendWith(MockitoExtension.class)
+class MemberServiceMockTest {
+
+    @InjectMocks
+    private MemberService sut;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @DisplayName("사용자 가입승인 서비스 Mock 테스트")
+    @Nested
+    class Approve {
+
+        @DisplayName("[계정 이름] 찾을 수 없음")
+        @Test
+        void givenNotFoundAccountName_thenThrowsWithACCOUNT_INFO_WRONG() {
+            // given
+            given(memberRepository.findByAccountName(anyString()))
+                    .willReturn(Optional.empty());
+
+            MemberApprovalRequest dto = mock(MemberApprovalRequest.class);
+            String wrongAccountName = "wrongAccountName";
+            given(dto.getAccountName())
+                    .willReturn(wrongAccountName);
+
+            // when, then
+            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
+        }
+
+    }
+
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
@@ -7,7 +7,6 @@ import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.MemberRepository;
 import com.wanted.teamr.snsfeedintegration.util.ApprovalCodeGenerator;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -21,6 +20,7 @@ import java.util.stream.Stream;
 
 import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 @DisplayName("사용자 서비스 통합 테스트")
@@ -48,7 +48,7 @@ class MemberServiceTest {
             MemberJoinRequest dto = MemberJoinRequest.of(ACCOUNT_NAME, EMAIL, PASSWORD);
 
             // when, then
-            Assertions.assertThatThrownBy(() -> sut.join(dto))
+            assertThatThrownBy(() -> sut.join(dto))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.DUPLICATE_ACCOUNT_NAME.getMessage());
         }
@@ -74,6 +74,7 @@ class MemberServiceTest {
 
     }
 
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @DisplayName("사용자 가입승인 서비스")
     @Order(2)
     @Nested
@@ -94,7 +95,7 @@ class MemberServiceTest {
             MemberApprovalRequest dto = MemberApprovalRequest.of(accountName, PASSWORD, approvalCode);
 
             // when, then
-            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+            assertThatThrownBy(() -> sut.approve(dto))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
         }
@@ -107,7 +108,7 @@ class MemberServiceTest {
             MemberApprovalRequest dto = MemberApprovalRequest.of(accountName, PASSWORD, approvalCode);
 
             // when, then
-            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+            assertThatThrownBy(() -> sut.approve(dto))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
         }
@@ -124,7 +125,7 @@ class MemberServiceTest {
             MemberApprovalRequest dto = MemberApprovalRequest.of(ACCOUNT_NAME, PASSWORD, approvalCode);
 
             // when, then
-            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+            assertThatThrownBy(() -> sut.approve(dto))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.APPROVAL_CODE_WRONG.getMessage());
         }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
@@ -94,6 +94,19 @@ class MemberServiceTest {
                     .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
         }
 
+        @DisplayName("[비밀번호] 불일치")
+        @ValueSource(strings = {"qlalfqjsgh479^^", "qlalfqjsgh486^", "qlalfqjsgh4866^^"})
+        @ParameterizedTest
+        void givenWrongPassword_thenThrowsWithACCOUNT_INFO_WRONG(String accountName) {
+            // given
+            MemberApprovalRequest dto = MemberApprovalRequest.of(accountName, PASSWORD, approvalCode);
+
+            // when, then
+            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
+        }
+
     }
 
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
@@ -5,17 +5,16 @@ import com.wanted.teamr.snsfeedintegration.dto.MemberJoinRequest;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.MemberRepository;
-import com.wanted.teamr.snsfeedintegration.util.ApprovalCodeGenerator;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 @DisplayName("사용자 서비스 통합 테스트")
 @SpringBootTest
 class MemberServiceTest {
@@ -28,18 +27,17 @@ class MemberServiceTest {
     private PasswordEncoder passwordEncoder;
 
     @DisplayName("사용자 회원가입 서비스")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @Order(1)
     @Nested
     class Join {
 
         @DisplayName("계정 이름 중복")
+        @Order(2)
         @Test
         void givenDuplicateAccountName_thenThrowsCustomExceptionByDUPLICATE_ACCOUNT_NAME() {
             // given
-            MemberJoinRequest dto = MemberJoinRequest.of("jeonggoo75", "jeonggoo75@gmail.com", "qlalfqjsgh486^^");
-            String encodedPassword = passwordEncoder.encode(dto.getPassword());
-            String approvalCode = ApprovalCodeGenerator.generate();
-            Member member = Member.of(dto, encodedPassword, approvalCode);
-            memberRepository.save(member);
+            MemberJoinRequest dto = MemberJoinRequest.of(ACCOUNT_NAME, EMAIL, PASSWORD);
 
             // when, then
             Assertions.assertThatThrownBy(() -> sut.join(dto))
@@ -48,10 +46,11 @@ class MemberServiceTest {
         }
 
         @DisplayName("성공")
+        @Order(1)
         @Test
         void givenNotDuplicateAccountName_thenSuccess() {
             // given
-            MemberJoinRequest dto = MemberJoinRequest.of("sampleuser123", "sampleuser123@gmail.com", "qlalfqjsgh486^^");
+            MemberJoinRequest dto = MemberJoinRequest.of(ACCOUNT_NAME, EMAIL, PASSWORD);
 
             // when
             Long memberId = sut.join(dto);

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
@@ -1,12 +1,15 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
 import com.wanted.teamr.snsfeedintegration.domain.Member;
+import com.wanted.teamr.snsfeedintegration.dto.MemberApprovalRequest;
 import com.wanted.teamr.snsfeedintegration.dto.MemberJoinRequest;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -62,6 +65,33 @@ class MemberServiceTest {
             assertThat(passwordEncoder.matches(dto.getPassword(), foundMember.getPassword())).isTrue();
             assertThat(foundMember.getApprovalCode()).hasSize(6);
             assertThat(foundMember.getIsApproved()).isFalse();
+        }
+
+    }
+
+    @DisplayName("사용자 가입승인 서비스")
+    @Order(2)
+    @Nested
+    class Approve {
+
+        private String approvalCode;
+
+        @BeforeEach
+        void setUp() {
+            approvalCode = memberRepository.findById(1L).orElseThrow().getApprovalCode();
+        }
+
+        @DisplayName("[계정 이름] 찾을 수 없음")
+        @ValueSource(strings = {"myaccoun", "myaccount2"})
+        @ParameterizedTest
+        void givenNotFoundAccountName_thenThrowsWithACCOUNT_INFO_WRONG(String accountName) {
+            // given
+            MemberApprovalRequest dto = MemberApprovalRequest.of(accountName, PASSWORD, approvalCode);
+
+            // when, then
+            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
         }
 
     }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
@@ -6,13 +6,18 @@ import com.wanted.teamr.snsfeedintegration.dto.MemberJoinRequest;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.MemberRepository;
+import com.wanted.teamr.snsfeedintegration.util.ApprovalCodeGenerator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -105,6 +110,28 @@ class MemberServiceTest {
             Assertions.assertThatThrownBy(() -> sut.approve(dto))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.ACCOUNT_INFO_WRONG.getMessage());
+        }
+
+        @DisplayName("[승인코드] 불일치")
+        @MethodSource("getApprovalCodeStream")
+        @ParameterizedTest
+        void givenWrongApprovalCode_thenThrowsWithACCOUNT_INFO_WRONG(String approvalCode) {
+            if (approvalCode.equals(this.approvalCode)) {
+                return;
+            }
+
+            // given
+            MemberApprovalRequest dto = MemberApprovalRequest.of(ACCOUNT_NAME, PASSWORD, approvalCode);
+
+            // when, then
+            Assertions.assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.APPROVAL_CODE_WRONG.getMessage());
+        }
+
+        private static Stream<String> getApprovalCodeStream() {
+            return IntStream.range(0, 5)
+                    .mapToObj(i -> ApprovalCodeGenerator.generate());
         }
 
     }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/MemberServiceTest.java
@@ -135,6 +135,34 @@ class MemberServiceTest {
                     .mapToObj(i -> ApprovalCodeGenerator.generate());
         }
 
+        @Order(1)
+        @DisplayName("성공")
+        @Test
+        void whenSuccess_thenMemberIsApproved() {
+            // given
+            MemberApprovalRequest dto = MemberApprovalRequest.of(ACCOUNT_NAME, PASSWORD, approvalCode);
+
+            // when
+            sut.approve(dto);
+
+            // then
+            Member member = memberRepository.findByAccountName(ACCOUNT_NAME).orElseThrow();
+            assertThat(member.getIsApproved()).isTrue();
+        }
+
+        @Order(2)
+        @DisplayName("이미 가입승인 완료")
+        @Test
+        void givenAlreadyApproved_thenThrowsWithALREADY_APPROVED() {
+            // given
+            MemberApprovalRequest dto = MemberApprovalRequest.of(ACCOUNT_NAME, PASSWORD, approvalCode);
+
+            // when, then
+            assertThatThrownBy(() -> sut.approve(dto))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.ALREADY_APPROVED.getMessage());
+        }
+
     }
 
 }


### PR DESCRIPTION
## 📃 설명

- resolves #22 
    - (POST /api/members/approve API)

## 🔨 작업 내용

1. 컨트롤러 구현 및 컨트롤러 WebMvc 테스트
    - RequestBody의 Validation 검증 수행
    - 필요한 에러코드 추가 (APPROVAL_CODE_BLANK, APPROVAL_CODE_INVALID_FORMAT)
2. 서비스 구현 및 테스트
    - 사용자 조회를 위한 MemberRepository에 findByAccountName 정의
    - 필요한 에러코드 추가 (ACCOUNT_INFO_WRONG, APPROVAL_CODE_WRONG, ALREADY_APPROVED)
    - mock 테스트 후 통합 테스트 수행
3. 컨트롤러 통합 테스트
    - 당장은 서비스 통합테스트와 중복이라 성공, 이미 가입승인 완료의 2가지 최종 분기 케이스만 테스트함
