### PR TITLE
 feat: 게시물 공유 API 구현

### DIFF
--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
@@ -26,4 +26,10 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/api/posts/{postId}/share")
+    public ResponseEntity<?> sharePost(@PathVariable("postId") Long postId) {
+        postService.sharePost(postId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
@@ -70,4 +70,8 @@ public class Post extends BaseEntity {
         likeCount += 1;
     }
 
+    public void increaseShareCount() {
+        shareCount += 1;
+    }
+
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
@@ -32,4 +32,14 @@ public class PostService {
         post.increaseLikeCount();
         postRepository.save(post);
     }
+
+    @Transactional
+    public void sharePost(Long postId) {
+        Post post = postRepository.findByIdForUpdate(postId)
+                                  .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        snsService.sharePost(post.getContentId(), post.getType());
+
+        post.increaseShareCount();
+    }
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
@@ -45,4 +45,34 @@ public class SnsService {
 
         return true;
     }
+
+    /**
+     * 본 서비스가 아닌 실제 외부 SNS의 공유 API를 호출여 공유 기능을 처리합니다.
+     *
+     * @param contentId 게시물이 해당하는 SNS에서 관리되는 고유 인식 값
+     * @param snsType   SNS 종류
+     * @return 외부 SNS 게시물 공유 기능 동작 성공 여부
+     */
+    public boolean sharePost(String contentId, SnsType snsType) {
+        String domain = externalApiConfig.getSnsApiDomains()
+                                         .get(snsType.name());
+        String path = String.format(externalApiConfig.getPostPath()
+                                                     .get("share"), contentId);
+        String url = String.format("%s%s", domain, path);
+
+
+        /**
+         * 외부 API 통신에 대한 로직을 보여주기 위한 코드로
+         * webClientService구현체 webClientServiceImpl에서 send 함수가 항상 null을 반환합니다.
+         * 그래서 아래 코드의 주석 처리를 지우면 외부 API 통신에 대해 항상 실패합니다.
+         */
+        // TODO: 외부 API 호출 구현
+        /*HttpResponse response = webClientService.send(url, HttpMethod.POST);
+        int httpStatus = response.statusCode();
+        if (httpStatus != HttpStatus.OK.value()) {
+            // throw exception
+        }*/
+
+        return true;
+    }
 }

--- a/src/main/resources/external-api-config.yml
+++ b/src/main/resources/external-api-config.yml
@@ -7,4 +7,5 @@ external-api:
 
   post-path:
     like: "likes/%s"
+    share: "share/%s"
 

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -55,7 +55,7 @@ class PostServiceConcurrencyTest {
                 try {
                     postService.likePost(post.getId());
                 } catch (CustomException ex) {
-                    System.out.println(ex.getErrorCode());
+                    System.out.println(ex.getErrorCodeType());
                 } catch (Exception ex) {
                     System.out.println(ex);
                 } finally {
@@ -72,4 +72,5 @@ class PostServiceConcurrencyTest {
         assertThat(samePost.getLikeCount()).isEqualTo(totalExecutedCnt);
         postRepository.delete(samePost);
     }
+
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -73,4 +73,51 @@ class PostServiceConcurrencyTest {
         postRepository.delete(samePost);
     }
 
+    @Test
+    @DisplayName("게시물 공유 기능 멀티 스레드로 동시에 총 100번 요청")
+    public void sharePostMultiThreadRequest100() throws InterruptedException {
+        // given: 공유 수가 0인 게시글 설정
+        Post post = Post.builder()
+                        .contentId("126789")
+                        .type(SnsType.THREADS)
+                        .title("게시물 제목123")
+                        .content("게시물 내용123")
+                        .viewCount(0L)
+                        .likeCount(0L)
+                        .shareCount(0L)
+                        .createdAt(LocalDateTime.of(2023, 4, 5, 5, 23, 33))
+                        .updatedAt(LocalDateTime.of(2023, 7, 6, 5, 23, 33))
+                        .build();
+        postRepository.save(post);
+        assertThat(post.getShareCount()).isEqualTo(0L);
+
+        int totalExecutedCnt = 100;
+        int threadCnt = 16;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCnt);
+        CountDownLatch latch = new CountDownLatch(totalExecutedCnt);
+
+        // when: threadCnt개 만큼 스레드가 멀티스레드 방식으로 총 totalExecutedCnt번 게시글 공유 요청
+        for (int idx = 0; idx < totalExecutedCnt; idx++) {
+            executorService.execute(() -> {
+                try {
+                    postService.sharePost(post.getId());
+                } catch (CustomException ex) {
+                    System.out.println(ex.getErrorCodeType());
+                } catch (Exception ex) {
+                    System.out.println(ex);
+                } finally {
+                    // CountDownLatch를 줄여 스레드가 완료됨을 알림
+                    latch.countDown();
+                }
+            });
+        }
+        // 모든 스레드가 완료될 때까지 대기
+        latch.await();
+
+        // then: 게시글의 공유 수가 총 실행 횟수인 totalExecutedCnt와 같아야 한다
+        Post samePost = postRepository.findById(post.getId()).get();
+        assertThat(samePost.getShareCount()).isEqualTo(totalExecutedCnt);
+        postRepository.delete(samePost);
+    }
+
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
@@ -18,7 +18,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -87,7 +88,7 @@ class PostServiceMockTest {
         // when, then
         assertThatThrownBy(() -> postService.getPost(postId))
                 .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
+                .extracting("errorCodeType")
                 .isEqualTo(ErrorCode.POST_NOT_FOUND);
     }
 

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
@@ -1,5 +1,6 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
+import com.wanted.teamr.snsfeedintegration.config.ExternalApiConfig;
 import com.wanted.teamr.snsfeedintegration.domain.Post;
 import com.wanted.teamr.snsfeedintegration.domain.PostHashtag;
 import com.wanted.teamr.snsfeedintegration.domain.SnsType;
@@ -20,7 +21,11 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +36,12 @@ class PostServiceMockTest {
 
     @InjectMocks
     PostService postService;
+
+    @Mock
+    SnsService snsService;
+
+    @Mock
+    ExternalApiConfig externalApiConfig;
 
     @DisplayName("게시물 한 건에 대한 상세 정보를 가져온다.")
     @Test
@@ -90,6 +101,55 @@ class PostServiceMockTest {
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCodeType")
                 .isEqualTo(ErrorCode.POST_NOT_FOUND);
+    }
+
+    @DisplayName("게시물 공유 성공")
+    @Test
+    void sharePost() {
+        // given: 게시물이 존재하도록 설정
+        Long postId = 12321L;
+        Long shareCount = 10235L;
+        Post post = Post.builder()
+                        .contentId("1234567")
+                        .type(SnsType.INSTAGRAM)
+                        .title("강아지 졸귀")
+                        .content("우리집 강아지 보고가세요")
+                        .viewCount(225672L)
+                        .likeCount(45333L)
+                        .shareCount(shareCount)
+                        .createdAt(LocalDateTime.of(2023, 8, 10, 8, 5, 22))
+                        .updatedAt(LocalDateTime.of(2023, 8, 13, 17, 35, 42))
+                        .build();
+        given(postRepository.findByIdForUpdate(postId)).willReturn(Optional.of(post));
+        given(snsService.sharePost(post.getContentId(), post.getType())).willReturn(true);
+
+        // when
+        postService.sharePost(postId);
+
+        // then: 공유 수가 +1 됐는지 확인
+        assertAll(
+                () -> verify(postRepository).findByIdForUpdate(postId),
+                () -> verify(snsService).sharePost(post.getContentId(), post.getType()),
+                () -> assertThat(post.getShareCount()).isEqualTo(shareCount + 1)
+        );
+    }
+
+    @DisplayName("게시물을 공유할 때 게시물 id에 해당하는 게시물을 찾을 수 없어 예외가 발생한다.")
+    @Test
+    void sharePostFailedPostNotFound() {
+        // given: postId에 해당하는 게시물이 존재하지 않도록 설정
+        Long postId = 222500L;
+        given(postRepository.findByIdForUpdate(postId)).willReturn(Optional.empty());
+
+        // when
+        CustomException ex = assertThrows(CustomException.class, () -> postService.sharePost(postId));
+
+        // then: POST_NOT_FOUND 예외 발생 확인
+        assertAll(
+                () -> assertThat(ex.getErrorCodeType()).isEqualTo(ErrorCode.POST_NOT_FOUND),
+                () -> verify(postRepository).findByIdForUpdate(postId),
+                () -> verify(snsService, never()).sharePost(any(String.class), any(SnsType.class))
+        );
     }
 
 }


### PR DESCRIPTION
## 📃 설명

- resolves #21

## 🔨 작업 내용

1. 게시물 공유 API 구현
2. 게시물 공유 서비스 레이어 단위 테스트 작성
3. 게시물 공유 컨트롤러 레이어 단위, 통합 테스트 작성
4. 게시물 공유 동시성 테스트 작성
    - 테스트가 조금 더 빠르게 돌아가게 하고 100번으로도 충분히 검증이 돼서 1000번이 아닌 100번만 요청하게 설정했습니다
6. external-api-config.yml 파일에 게시물 공유 api path 정보 추가

## 💬 기타 사항

참고
- 게시물 공유 기능은 #15 에서 미리 구현한 클래스를 사용합니다.
1. 외부 SNS 서비스 기능 담당하는 클래스 (SnsService)
    - sns type에 따른 api 호출 url을 만들고 외부 SNS API를 호출하여 SNS의 게시물 좋아요, 공유 요청 담당
2. 외부 API 호출 기능 담당 클래스 (WebClientService, WebClientServiceImple)
    - SnsService 에서 외부 API 호출에 대한 로직을 표현하고 싶어서 만든 클래스
    - 기능 개발을 위한 요소로, 실제로 외부 API 호출은 동작하지 않습니다.

TODO
- 해당 PR에서 게시물 좋아요 기능 관련된 코드 수정, 주석 수정, 테스트 작성해도 되는데 동작 방식이 같을뿐 다른 API라 따로 PR 생성해서 게시물 좋아요 테스트 작성 예정
  - 게시물 공유에서는 `postRepository.save(post);` 뺐는데 현재 PR에서 게시물 좋아요 기능에서는 `postRepository.save(post);` 코드가 있습니다. 다음 PR에서 수정하겠습니다
  - security 설정 적용 후에 반영해서 코드 수정할 것이 있으니 다음 PR에서 security 반영한 로직 수정이랑 테스트 코드 보완한 PR 생성하겠습니다
- 다음 PR에서 게시물 좋아요 동시성 테스트 횟수도 100번으로 줄일 예정
