### PR TITLE
feat: Security 설정 적용 후 게시물 공유, 좋아요 API 유저 관련 로직 추가 및 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+	//runtimeOnly 'com.h2database:h2'
+	testImplementation 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
@@ -1,6 +1,8 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
+import com.wanted.teamr.snsfeedintegration.domain.Member;
 import com.wanted.teamr.snsfeedintegration.dto.PostGetResponse;
+import com.wanted.teamr.snsfeedintegration.security.CurrentMember;
 import com.wanted.teamr.snsfeedintegration.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,14 +23,14 @@ public class PostController {
     }
 
     @PostMapping("/api/posts/{postId}/like")
-    public ResponseEntity<?> likePost(@PathVariable("postId") Long postId) {
-        postService.likePost(postId);
+    public ResponseEntity<?> likePost(@PathVariable("postId") Long postId, @CurrentMember Member member) {
+        postService.likePost(postId, member);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/api/posts/{postId}/share")
-    public ResponseEntity<?> sharePost(@PathVariable("postId") Long postId) {
-        postService.sharePost(postId);
+    public ResponseEntity<?> sharePost(@PathVariable("postId") Long postId, @CurrentMember Member member) {
+        postService.sharePost(postId, member);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
@@ -35,7 +35,7 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Authority authority;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private Member(String accountName, String email, String password, String approvalCode, Boolean isApproved) {
         this.accountName = accountName;
         this.email = email;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
@@ -42,6 +42,7 @@ public class Member extends BaseEntity {
         this.password = password;
         this.approvalCode = approvalCode;
         this.isApproved = isApproved;
+        authority = Authority.ROLE_USER;
     }
 
     public static Member of(MemberJoinRequest dto, String encodedPassword, String approvalCode) {

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Member.java
@@ -9,11 +9,13 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "accountName", callSuper = false)
 @Entity
 public class Member extends BaseEntity {
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/security/CurrentMember.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/security/CurrentMember.java
@@ -1,0 +1,14 @@
+package com.wanted.teamr.snsfeedintegration.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "member")
+public @interface CurrentMember {
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/security/SecurityConfig.java
@@ -3,13 +3,11 @@ package com.wanted.teamr.snsfeedintegration.security;
 import com.wanted.teamr.snsfeedintegration.jwt.JwtAccessDeniedHandler;
 import com.wanted.teamr.snsfeedintegration.jwt.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,10 +29,6 @@ public class SecurityConfig {
                                 .accessDeniedHandler(jwtAccessDeniedHandler())
                                 .authenticationEntryPoint(jwtAuthenticationEntryPoint())
                 )
-                // enable h2-console
-                .headers((headers) ->
-                        headers.contentTypeOptions(contentTypeOptionsConfig ->
-                                headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)))
                 // disable session
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -43,7 +37,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
                                 .requestMatchers("/api/members/**").permitAll()
-                                .requestMatchers(PathRequest.toH2Console()).permitAll()
                                 .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
@@ -1,5 +1,6 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
+import com.wanted.teamr.snsfeedintegration.domain.Member;
 import com.wanted.teamr.snsfeedintegration.domain.Post;
 import com.wanted.teamr.snsfeedintegration.dto.PostGetResponse;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
@@ -23,22 +24,21 @@ public class PostService {
     }
 
     @Transactional
-    public void likePost(Long postId) {
+    public void likePost(Long postId, Member member) {
         Post post = postRepository.findByIdForUpdate(postId)
                                   .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-        snsService.likePost(post.getContentId(), post.getType());
+        snsService.likePost(post.getContentId(), post.getType(), member);
 
         post.increaseLikeCount();
-        postRepository.save(post);
     }
 
     @Transactional
-    public void sharePost(Long postId) {
+    public void sharePost(Long postId, Member member) {
         Post post = postRepository.findByIdForUpdate(postId)
                                   .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-        snsService.sharePost(post.getContentId(), post.getType());
+        snsService.sharePost(post.getContentId(), post.getType(), member);
 
         post.increaseShareCount();
     }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/SnsService.java
@@ -1,6 +1,7 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
 import com.wanted.teamr.snsfeedintegration.config.ExternalApiConfig;
+import com.wanted.teamr.snsfeedintegration.domain.Member;
 import com.wanted.teamr.snsfeedintegration.domain.SnsType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,26 +18,32 @@ public class SnsService {
     private final ExternalApiConfig externalApiConfig;
 
     /**
-     * 본 서비스가 아닌 실제 외부 SNS 서비스에서의 좋아요 API를 호출하여
-     * 좋아요 기능을 처리합니다.
+     * 본 서비스가 아닌 실제 외부 SNS의 좋아요 API를 호출하여 좋아요 기능을 처리합니다.
      *
      * @param contentId 게시물이 해당하는 SNS에서 관리되는 고유 인식 값
      * @param snsType   SNS 서비스 종류
+     * @param member 게시물 좋아요를 요청한 유저 정보
      * @return 외부 SNS 서비스 좋아요 기능 동작 성공 여부
      */
-    public boolean likePost(String contentId, SnsType snsType) {
+    public boolean likePost(String contentId, SnsType snsType, Member member) {
         String domain = externalApiConfig.getSnsApiDomains()
                                          .get(snsType.name());
         String path = String.format(externalApiConfig.getPostPath()
                                                      .get("like"), contentId);
         String url = String.format("%s%s", domain, path);
 
-        // TODO: 외부 API 호출 통신 구현
+        /**
+         * 게시물 좋아요를 요청한 유저 정보는 본 서비스에 좋아요 요청 내역을 저장하거나
+         * 외부 SNS 좋아요 API 호출할 때 필요한 정보겠지만 현재 개발 사항에서는
+         * 아직 member entity를 직접 다루는 로직이 없습니다
+         */
+
         /**
          * 외부 API 통신에 대한 로직을 보여주기 위한 코드로
          * webClientService구현체 webClientServiceImpl에서 send 함수가 항상 null을 반환합니다.
          * 그래서 아래 코드의 주석 처리를 지우면 외부 API 통신에 대해 항상 실패합니다.
          */
+        // TODO: 외부 API 호출 통신 구현
         /*HttpResponse response = webClientService.send(url, HttpMethod.POST);
         int httpStatus = response.statusCode();
         if (httpStatus != HttpStatus.OK.value()) {
@@ -47,19 +54,25 @@ public class SnsService {
     }
 
     /**
-     * 본 서비스가 아닌 실제 외부 SNS의 공유 API를 호출여 공유 기능을 처리합니다.
+     * 본 서비스가 아닌 실제 외부 SNS의 공유 API를 호출하여 공유 기능을 처리합니다.
      *
      * @param contentId 게시물이 해당하는 SNS에서 관리되는 고유 인식 값
      * @param snsType   SNS 종류
+     * @param member 게시물 좋아요를 요청한 유저 정보
      * @return 외부 SNS 게시물 공유 기능 동작 성공 여부
      */
-    public boolean sharePost(String contentId, SnsType snsType) {
+    public boolean sharePost(String contentId, SnsType snsType, Member member) {
         String domain = externalApiConfig.getSnsApiDomains()
                                          .get(snsType.name());
         String path = String.format(externalApiConfig.getPostPath()
                                                      .get("share"), contentId);
         String url = String.format("%s%s", domain, path);
 
+        /**
+         * 게시물 공유를 요청한 유저 정보는 본 서비스에 공유 요청 내역을 저장하거나
+         * 외부 SNS 공유 API 호출할 때 필요한 정보겠지만 현재 개발 사항에서는
+         * 아직 member entity를 직접 다루는 로직이 없습니다
+         */
 
         /**
          * 외부 API 통신에 대한 로직을 보여주기 위한 코드로

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
     init:
       mode: always
       data-locations: classpath:db/data.sql
+  config:
+    import: external-api-config.yml
 
 logging:
   level:

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerMockTest.java
@@ -7,8 +7,12 @@ import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCodeType;
 import com.wanted.teamr.snsfeedintegration.exception.RequestBodyErrorCode;
 import com.wanted.teamr.snsfeedintegration.security.JwtSecurityConfig;
+import com.wanted.teamr.snsfeedintegration.jwt.JwtAccessDeniedHandler;
+import com.wanted.teamr.snsfeedintegration.jwt.JwtAuthenticationEntryPoint;
+import com.wanted.teamr.snsfeedintegration.jwt.TokenProvider;
 import com.wanted.teamr.snsfeedintegration.security.SecurityConfig;
 import com.wanted.teamr.snsfeedintegration.service.MemberService;
+import com.wanted.teamr.snsfeedintegration.service.UserDetailsServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,7 +26,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.*;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.ACCOUNT_NAME;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.APPROVAL_CODE;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.BLANK;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.EMAIL;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.EMAIL_HEAD;
+import static com.wanted.teamr.snsfeedintegration.controller.TestConstants.PASSWORD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -44,6 +53,14 @@ class MemberControllerMockTest {
     private MemberService memberService;
     @Autowired
     private ObjectMapper mapper;
+    @MockBean
+    private UserDetailsServiceImpl userDetailsServiceImpl;
+    @MockBean
+    private TokenProvider tokenProvider;
+    @MockBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    @MockBean
+    private JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @DisplayName("/join 사용자 회원가입 WebMvc")
     @Nested

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerMockTest.java
@@ -103,6 +103,41 @@ class PostControllerMockTest {
                .andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND.getMessage()));
     }
 
+    @DisplayName("게시물 좋아요에 성공하면 200 OK로 응답한다.")
+    @WithAuthUser
+    @Test
+    void likePost() throws Exception {
+        // given
+        Long postId = 777L;
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/posts/{postId}/like", postId).with(csrf()))
+                                      .andDo(print());
+        // then
+        verify(postService).likePost(postId, member);
+        result.andExpect(status().isOk());
+    }
+
+    @DisplayName("게시물 좋아요 요청할 때 게시물 id에 해당하는 게시물을 찾을 수 없어 예외가 발생한다.")
+    @WithAuthUser
+    @Test
+    void likePostFailedPostNotFound() throws Exception {
+        // given
+        Long postId = 5000L;
+        doThrow(new CustomException(ErrorCode.POST_NOT_FOUND)).when(postService)
+                                                              .likePost(postId, member);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/posts/{postId}/like", postId).with(csrf()))
+                                      .andDo(print());
+
+        // then
+        result.andExpect(status().isNotFound())
+              .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+              .andExpect(jsonPath("$.errorCode").value(ErrorCode.POST_NOT_FOUND.name()))
+              .andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND.getMessage()));
+    }
+
     @DisplayName("게시물 공유에 성공하면 200 OK로 응답한다.")
     @WithAuthUser
     @Test

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
@@ -100,6 +100,55 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND.getMessage()));
     }
 
+    @DisplayName("게시물 좋아요에 성공하면 200 OK로 응답한다.")
+    @WithAuthUser
+    @Test
+    void likePost() throws Exception {
+        // given
+        Post post = Post.builder()
+                        .contentId("5668")
+                        .type(SnsType.INSTAGRAM)
+                        .title("우리집 고양이")
+                        .content("우리집 고양이 보고가세요")
+                        .viewCount(21600L)
+                        .likeCount(7775L)
+                        .shareCount(555L)
+                        .createdAt(LocalDateTime.of(2021, 8, 10, 8, 5, 22))
+                        .updatedAt(LocalDateTime.of(2021, 8, 17, 17, 35, 42))
+                        .build();
+        PostHashtag.builder()
+                   .post(post)
+                   .hashtag("고양이")
+                   .build();
+        PostHashtag.builder()
+                   .post(post)
+                   .hashtag("냥스타그램")
+                   .build();
+        postRepository.save(post);
+        Long postId = post.getId();
+
+        // when, then
+        mockMvc.perform(post("/api/posts/{postId}/like", postId))
+               .andDo(print())
+               .andExpect(status().isOk());
+    }
+
+    @DisplayName("게시물 좋아요 요청할 때 게시물 id에 해당하는 게시물을 찾을 수 없어 예외가 발생한다.")
+    @WithAuthUser
+    @Test
+    void likePostFailedPostNotFound() throws Exception {
+        // given
+        Long postId = 808080L;
+
+        // when, then
+        mockMvc.perform(post("/api/posts/{postId}/like", postId))
+               .andDo(print())
+               .andExpect(status().isNotFound())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+               .andExpect(jsonPath("$.errorCode").value(ErrorCode.POST_NOT_FOUND.name()))
+               .andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND.getMessage()));
+    }
+
     @DisplayName("게시물 공유에 성공하면 200 OK로 응답한다.")
     @WithAuthUser
     @Test

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
@@ -5,6 +5,7 @@ import com.wanted.teamr.snsfeedintegration.domain.PostHashtag;
 import com.wanted.teamr.snsfeedintegration.domain.SnsType;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.PostRepository;
+import com.wanted.teamr.snsfeedintegration.security.WithAuthUser;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,9 @@ import java.util.List;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -98,7 +101,7 @@ public class PostControllerTest {
     }
 
     @DisplayName("게시물 공유에 성공하면 200 OK로 응답한다.")
-    @WithMockUser
+    @WithAuthUser
     @Test
     void sharePost() throws Exception {
         // given
@@ -131,7 +134,7 @@ public class PostControllerTest {
     }
 
     @DisplayName("게시물을 공유할 때 게시물 id에 해당하는 게시물을 찾을 수 없어 예외가 발생한다.")
-    @WithMockUser
+    @WithAuthUser
     @Test
     void sharePostFailedPostNotFound() throws Exception {
         // given

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/fixture/JwtFixture.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/fixture/JwtFixture.java
@@ -1,0 +1,15 @@
+package com.wanted.teamr.snsfeedintegration.fixture;
+
+public final class JwtFixture {
+
+
+    public static String INVALID_AT = "eyJhbGci1NiJ9.eyJzdWXNCAig2NjAzNDB9.Tzd8X31";
+    /**
+     * exp = 1698660340 = Mon Oct 30 2023 19:05:40 UTC+0900 (한국 표준시)
+     */
+    public static String EXPIRED_AT_MEMBER1 = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0SWQiLCJleHAiOjE2OTg2NjAzNDB9.Tzd8X3Xnt1V17e6OENjYY0eOcjGpcrSA2NqGS819rZc";
+    /**
+     * exp = 32503647600 = Wed Jan 01 3000 00:00:00 UTC+0900 (한국 표준시)
+     */
+    public static String VAILD_AT_MEMBER1 = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0SWQiLCJleHAiOjMyNTAzNjQ3NjAwfQ.ZF3HcyE_q3jJiIJ0KB8nRfapmy4u-OJTX1ldNJxXcnk";
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/fixture/JwtFixture.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/fixture/JwtFixture.java
@@ -3,13 +3,13 @@ package com.wanted.teamr.snsfeedintegration.fixture;
 public final class JwtFixture {
 
 
-    public static String INVALID_AT = "eyJhbGci1NiJ9.eyJzdWXNCAig2NjAzNDB9.Tzd8X31";
+    public static String INVALID_AT = "Bearer eyJhbGci1NiJ9.eyJzdWXNCAig2NjAzNDB9.Tzd8X31";
     /**
      * exp = 1698660340 = Mon Oct 30 2023 19:05:40 UTC+0900 (한국 표준시)
      */
-    public static String EXPIRED_AT_MEMBER1 = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0SWQiLCJleHAiOjE2OTg2NjAzNDB9.Tzd8X3Xnt1V17e6OENjYY0eOcjGpcrSA2NqGS819rZc";
+    public static String EXPIRED_AT_MEMBER1 = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0SWQiLCJhdXRoIjoiUk9MRV9VU0VSIiwiZXhwIjoxNjk4NjY0MDYwfQ.OIK6yD_WhUIFWlaTheY29OPfp24bJ6qIxacLAF21GQo";
     /**
      * exp = 32503647600 = Wed Jan 01 3000 00:00:00 UTC+0900 (한국 표준시)
      */
-    public static String VAILD_AT_MEMBER1 = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0SWQiLCJleHAiOjMyNTAzNjQ3NjAwfQ.ZF3HcyE_q3jJiIJ0KB8nRfapmy4u-OJTX1ldNJxXcnk";
+    public static String VAILD_AT_MEMBER1 = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0SWQiLCJhdXRoIjoiUk9MRV9VU0VSIiwiZXhwIjozMjUwMzY0NzYwMH0.UzzGTYcI6ioQ1euYsF21-CE5N0SPa5WtmQSnjUKVap8";
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/fixture/MemberFixture.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/fixture/MemberFixture.java
@@ -1,0 +1,17 @@
+package com.wanted.teamr.snsfeedintegration.fixture;
+
+
+import com.wanted.teamr.snsfeedintegration.domain.Member;
+
+public final class MemberFixture {
+
+    public static Member MEMBER1() {
+        return Member.builder()
+                     .accountName("testId")
+                     .email("testEmail12321@gmail.com")
+                     .password("testpassword123")
+                     .approvalCode("cXh9d8")
+                     .isApproved(true)
+                     .build();
+    }
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/security/WithAuthUser.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/security/WithAuthUser.java
@@ -1,0 +1,12 @@
+package com.wanted.teamr.snsfeedintegration.security;
+
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithAuthUserSecurityContextFactory.class)
+public @interface WithAuthUser {
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/security/WithAuthUserSecurityContextFactory.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/security/WithAuthUserSecurityContextFactory.java
@@ -1,0 +1,36 @@
+package com.wanted.teamr.snsfeedintegration.security;
+
+import com.wanted.teamr.snsfeedintegration.domain.Authority;
+import com.wanted.teamr.snsfeedintegration.domain.UserDetailsImpl;
+import com.wanted.teamr.snsfeedintegration.fixture.JwtFixture;
+import com.wanted.teamr.snsfeedintegration.fixture.MemberFixture;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class WithAuthUserSecurityContextFactory implements WithSecurityContextFactory<WithAuthUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithAuthUser annotation) {
+        // TODO: 고정된 member entity 말고 지정할 수 있게 수정
+        // TODO: role도 고정된 값 말고 토큰에 있는 값 파싱에서 적용하게 수정
+
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(Authority.ROLE_USER.toString());
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(authority);
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(UserDetailsImpl.of(MemberFixture.MEMBER1()), JwtFixture.VAILD_AT_MEMBER1, authorities);
+        
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -37,8 +37,8 @@ class PostServiceConcurrencyTest {
     }
 
     @Test
-    @DisplayName("게시물 좋아요 기능 멀티 스레드로 동시에 총 1000번 요청")
-    public void postLikeMultiThreadRequest1000() throws InterruptedException {
+    @DisplayName("게시물 좋아요 기능 멀티 스레드로 동시에 총 100번 요청")
+    public void postLikeMultiThreadRequest100() throws InterruptedException {
         // given: 좋아요 수가 0인 게시글 설정
         Post post = Post.builder()
                         .contentId("123456789")
@@ -54,7 +54,7 @@ class PostServiceConcurrencyTest {
         postRepository.save(post);
         assertThat(post.getLikeCount()).isEqualTo(0L);
 
-        int totalExecutedCnt = 1000;
+        int totalExecutedCnt = 100;
         int threadCnt = 16;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCnt);
         CountDownLatch latch = new CountDownLatch(totalExecutedCnt);

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -1,9 +1,12 @@
 package com.wanted.teamr.snsfeedintegration.service;
 
+import com.wanted.teamr.snsfeedintegration.domain.Member;
 import com.wanted.teamr.snsfeedintegration.domain.Post;
 import com.wanted.teamr.snsfeedintegration.domain.SnsType;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import com.wanted.teamr.snsfeedintegration.fixture.MemberFixture;
 import com.wanted.teamr.snsfeedintegration.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +28,13 @@ class PostServiceConcurrencyTest {
 
     @Autowired
     private PostService postService;
+
+    private Member member;
+
+    @BeforeEach
+    void beforeEach() {
+        member = MemberFixture.MEMBER1();
+    }
 
     @Test
     @DisplayName("게시물 좋아요 기능 멀티 스레드로 동시에 총 1000번 요청")
@@ -53,7 +63,7 @@ class PostServiceConcurrencyTest {
         for (int idx = 0; idx < totalExecutedCnt; idx++) {
             executorService.execute(() -> {
                 try {
-                    postService.likePost(post.getId());
+                    postService.likePost(post.getId(), member);
                 } catch (CustomException ex) {
                     System.out.println(ex.getErrorCodeType());
                 } catch (Exception ex) {
@@ -100,7 +110,7 @@ class PostServiceConcurrencyTest {
         for (int idx = 0; idx < totalExecutedCnt; idx++) {
             executorService.execute(() -> {
                 try {
-                    postService.sharePost(post.getId());
+                    postService.sharePost(post.getId(), member);
                 } catch (CustomException ex) {
                     System.out.println(ex.getErrorCodeType());
                 } catch (Exception ex) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,3 +10,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  config:
+    import: external-api-config.yml
+


### PR DESCRIPTION
## 📃 설명

- resolves #29 
- 

## 🔨 작업 내용

1. 현재 유저 회원 가입할 때 권한 null로 들어가서 토큰 헤더에 포함해서 API 요청하면 시큐리티 필터에서 null 에러 발생
   - 일단 임시로 멤버 엔티티에서 권한 값 user로 디폴트 설정
2. 시큐리티 설정 적용 후 게시물 좋아요, 공유하기에 Member를 파라미터로 받도록 수정
3. 게시물 좋아요, 공유하기 수정하면서 깨진 테스트 수정
4. 게시물 좋아요 단위, 통합 테스트 추가 
5. Security에서 h2 관련 에러 발생해서 일단 h2 런타임 의존성 제거
6. Mock 데이터로 Member 비교하다가 같은 entity여도 상황에 따라 다른 entity라 판단해서 일단 EqualsAndHashCode 추가
    - Member에서 계정 이름 유니크 키라 계정 이름으로 비교
7. 컨트롤러 레이어에서 바로 인증된 Member entity 주입 받아 사용할 수 있도록 `@CurrentMember` 추가
8. 컨트롤러에서 `@CurrentMember Member member`를 단위 테스트에서 쉽게 적용해서 테스트 할 수 있도록 `@WithAuthUser` 추가
9. 테스트를 위한 Jwt 더미 데이터 추가
    - 테스트를 위해 3000년에 만료되는 유효 토큰, 이미 만료된 토큰 추가

## 💬 기타 사항
 - 같은 회원 로그인하고 또 바로 로그인하면 에러
   - 멤버랑 리프레시 토큰 1대1이고 save만으로 처리돼서 에러나는 것 같습니다
 - 돌아가게끔만 하기 위해서 작성된 코드가 좀 있습니다
 - WithAuthUser
   - https://k3068.tistory.com/96