### PR TITLE
feat #26: 게시물 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
@@ -1,13 +1,17 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
 import com.wanted.teamr.snsfeedintegration.dto.PostGetResponse;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchRequest;
 import com.wanted.teamr.snsfeedintegration.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -18,6 +22,11 @@ public class PostController {
     @GetMapping("/api/posts/{postId}")
     public PostGetResponse getPost(@PathVariable("postId") Long postId) {
         return postService.getPost(postId);
+    }
+
+    @GetMapping("/api/posts")
+    public List<PostGetResponse> getPostList(PostSearchRequest request, Pageable pageable) {
+        return postService.getPostList(request, pageable);
     }
 
     @PostMapping("/api/posts/{postId}/like")

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/Post.java
@@ -24,7 +24,7 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private String contentId;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "post", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<PostHashtag> postHashtags = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/SearchByType.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/SearchByType.java
@@ -4,7 +4,15 @@ import lombok.Getter;
 
 @Getter
 public enum SearchByType {
-    title,
-    content,
-    titleContent
+
+    TITLE("title"),
+    CONTENT("content"),
+    TITLE_CONTENT("title,content");
+
+    private final String value;
+
+    SearchByType(String value) {
+        this.value = value;
+    }
+
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/domain/SearchByType.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/domain/SearchByType.java
@@ -1,0 +1,10 @@
+package com.wanted.teamr.snsfeedintegration.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SearchByType {
+    title,
+    content,
+    titleContent
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostGetResponse.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostGetResponse.java
@@ -45,7 +45,7 @@ public class PostGetResponse {
         return PostGetResponse.builder()
                 .postId(post.getId())
                 .contentId(post.getContentId())
-                .type(post.getType().name())
+                .type(post.getType().name().toLowerCase())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .hashtags(hashtags)

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostSearchCondition.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostSearchCondition.java
@@ -21,4 +21,13 @@ public class PostSearchCondition {
         this.search = search;
     }
 
+    public static PostSearchCondition of(String hashtag, SnsType type, SearchByType searchBy, String search) {
+        return PostSearchCondition.builder()
+                .hashtag(hashtag)
+                .type(type)
+                .searchBy(searchBy)
+                .search(search)
+                .build();
+    }
+
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostSearchCondition.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostSearchCondition.java
@@ -1,0 +1,24 @@
+package com.wanted.teamr.snsfeedintegration.dto;
+
+import com.wanted.teamr.snsfeedintegration.domain.SearchByType;
+import com.wanted.teamr.snsfeedintegration.domain.SnsType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostSearchCondition {
+
+    private final String hashtag;
+    private final SnsType type;
+    private final SearchByType searchBy;
+    private final String search;
+
+    @Builder
+    private PostSearchCondition(String hashtag, SnsType type, SearchByType searchBy, String search) {
+        this.hashtag = hashtag;
+        this.type = type;
+        this.searchBy = searchBy;
+        this.search = search;
+    }
+
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostSearchRequest.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/PostSearchRequest.java
@@ -1,0 +1,20 @@
+package com.wanted.teamr.snsfeedintegration.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostSearchRequest {
+
+    private String hashtag;
+    private String type;
+    private String searchBy;
+    private String search;
+
+    private PostSearchRequest(String hashtag, String type, String searchBy, String search) {
+        this.hashtag = hashtag;
+        this.type = type;
+        this.searchBy = searchBy;
+        this.search = search;
+    }
+
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode implements ErrorCodeType {
     PASSWORD_PERSONAL_INFO("다른 개인정보와 유사한 비밀번호는 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
 //    PASSWORD_MOST_USED("통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_ACCOUNT_NAME("이미 같은 이름의 계정이 존재합니다", HttpStatus.BAD_REQUEST),
+    NOT_FOUND_SNS_TYPE("대응하는 소셜미디어 타입이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NOT_FOUND_SEARCH_BY_TYPE("대응하는 검색 기준이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     POST_NOT_FOUND("게시물이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepository.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Post p where p.id = :id")

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.wanted.teamr.snsfeedintegration.repository;
+
+import com.wanted.teamr.snsfeedintegration.domain.Post;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchCondition;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+
+    List<Post> search(PostSearchCondition condition, Pageable pageable);
+
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.wanted.teamr.snsfeedintegration.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.teamr.snsfeedintegration.domain.Post;
+import com.wanted.teamr.snsfeedintegration.domain.SearchByType;
+import com.wanted.teamr.snsfeedintegration.domain.SnsType;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchCondition;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+import static com.wanted.teamr.snsfeedintegration.domain.QPost.post;
+import static com.wanted.teamr.snsfeedintegration.domain.QPostHashtag.postHashtag;
+
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PostRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<Post> search(PostSearchCondition condition, Pageable pageable) {
+        JPAQuery<Post> query = queryFactory
+                .selectFrom(post)
+                .join(post.postHashtags, postHashtag)
+                .on(
+                        postHashtag.hashtag.eq(condition.getHashtag())
+                )
+                .where(
+                        typeEqual(condition.getType()),
+                        searchContain(condition.getSearchBy(), condition.getSearch())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+        for (Sort.Order o : pageable.getSort()) {
+            PathBuilder<Post> pathBuilder = new PathBuilder<>(post.getType(), post.getMetadata());
+            query.orderBy(
+                    new OrderSpecifier(
+                            o.isAscending() ? Order.ASC : Order.DESC,
+                            pathBuilder.get(o.getProperty())
+                    )
+            );
+        }
+        return query.fetch();
+    }
+
+    private BooleanExpression typeEqual(SnsType type) {
+        return type == null ? null : post.type.eq(type);
+    }
+
+    private BooleanExpression searchContain(SearchByType searchBy, String search) {
+        if (search == null) {
+            return null;
+        }
+
+        if (searchBy == SearchByType.title) {
+            return post.title.contains(search);
+        }
+
+        if (searchBy == SearchByType.content) {
+            return post.content.contains(search);
+        }
+
+        return post.title.contains(search).or(post.content.contains(search));
+    }
+
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryImpl.java
@@ -62,11 +62,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
             return null;
         }
 
-        if (searchBy == SearchByType.title) {
+        if (searchBy == SearchByType.TITLE) {
             return post.title.contains(search);
         }
 
-        if (searchBy == SearchByType.content) {
+        if (searchBy == SearchByType.CONTENT) {
             return post.content.contains(search);
         }
 

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
@@ -2,12 +2,18 @@ package com.wanted.teamr.snsfeedintegration.service;
 
 import com.wanted.teamr.snsfeedintegration.domain.Post;
 import com.wanted.teamr.snsfeedintegration.dto.PostGetResponse;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchCondition;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchRequest;
 import com.wanted.teamr.snsfeedintegration.exception.CustomException;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.PostRepository;
+import com.wanted.teamr.snsfeedintegration.util.PostSearchConditionConverter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -15,21 +21,29 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final SnsService snsService;
+    private final PostSearchConditionConverter converter;
 
     public PostGetResponse getPost(Long postId) {
         Post post = postRepository.findById(postId)
-                                  .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         return PostGetResponse.of(post);
     }
 
     @Transactional
     public void likePost(Long postId) {
         Post post = postRepository.findByIdForUpdate(postId)
-                                  .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
         snsService.likePost(post.getContentId(), post.getType());
 
         post.increaseLikeCount();
         postRepository.save(post);
     }
+
+    public List<PostGetResponse> getPostList(PostSearchRequest request, Pageable pageable) {
+        PostSearchCondition condition = converter.convert(request);
+        List<Post> posts = postRepository.search(condition, pageable);
+        return posts.stream().map(PostGetResponse::of).toList();
+    }
+
 }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/util/PostSearchConditionConverter.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/util/PostSearchConditionConverter.java
@@ -1,0 +1,51 @@
+package com.wanted.teamr.snsfeedintegration.util;
+
+import com.wanted.teamr.snsfeedintegration.domain.SearchByType;
+import com.wanted.teamr.snsfeedintegration.domain.SnsType;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchCondition;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchRequest;
+import com.wanted.teamr.snsfeedintegration.exception.CustomException;
+import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.util.StringUtils.hasText;
+
+@Component
+public class PostSearchConditionConverter {
+
+    public PostSearchCondition convert(PostSearchRequest request) {
+        String hashtag = resolveHashtag(request.getHashtag());
+        SnsType snsType = resolveSnsType(request.getType());
+        SearchByType searchByType = resolveSearchBy(request.getSearchBy());
+        return PostSearchCondition.of(hashtag, snsType, searchByType, request.getSearch());
+    }
+
+    private String resolveHashtag(String hashtag) {
+        // TODO: 만약 이 값이 null 이면 본인계정 hashtag 값을 사용한다.
+        return hashtag;
+    }
+
+    private SnsType resolveSnsType(String type) {
+        if (!hasText(type)) {
+            return null;
+        }
+
+        for (SnsType snsType : SnsType.values()) {
+            if (type.toUpperCase().equals(snsType.name())) {
+                return snsType;
+            }
+        }
+
+        throw new CustomException(ErrorCode.NOT_FOUND_SNS_TYPE);
+    }
+
+    private SearchByType resolveSearchBy(String searchBy) {
+        for (SearchByType searchByType : SearchByType.values()) {
+            if (searchBy.toLowerCase().equals(searchByType.getValue())) {
+                return searchByType;
+            }
+        }
+
+        throw new CustomException(ErrorCode.NOT_FOUND_SEARCH_BY_TYPE);
+    }
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/util/PostSearchConditionConverter.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/util/PostSearchConditionConverter.java
@@ -40,6 +40,10 @@ public class PostSearchConditionConverter {
     }
 
     private SearchByType resolveSearchBy(String searchBy) {
+        if (searchBy == null) {
+            return SearchByType.TITLE_CONTENT;
+        }
+
         for (SearchByType searchByType : SearchByType.values()) {
             if (searchBy.toLowerCase().equals(searchByType.getValue())) {
                 return searchByType;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,9 @@ spring:
       data-locations: classpath:db/data.sql
 
   config:
-    import: external-api-config.yml
+    import:
+      - external-api-config.yml
+      - pageable-config.yml
 
 logging:
   level:

--- a/src/main/resources/pageable-config.yml
+++ b/src/main/resources/pageable-config.yml
@@ -1,0 +1,10 @@
+spring:
+  data:
+    web:
+      pageable:
+        default-page-size: 10
+        max-page-size: 100
+        size-parameter: pageCount
+        page-parameter: page
+      sort:
+        sort-parameter: orderBy

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
@@ -1,13 +1,19 @@
 package com.wanted.teamr.snsfeedintegration.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wanted.teamr.snsfeedintegration.domain.Post;
 import com.wanted.teamr.snsfeedintegration.domain.PostHashtag;
 import com.wanted.teamr.snsfeedintegration.domain.SnsType;
 import com.wanted.teamr.snsfeedintegration.exception.ErrorCode;
 import com.wanted.teamr.snsfeedintegration.repository.PostRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,11 +23,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@DisplayName("Posts API 통합 테스트")
 @AutoConfigureMockMvc
 @SpringBootTest
 public class PostControllerTest {
@@ -32,68 +40,799 @@ public class PostControllerTest {
     @Autowired
     PostRepository postRepository;
 
-    @DisplayName("게시물 상세 정보 응답을 보낸다.")
-    @WithMockUser
-    @Test
-    void getPost() throws Exception {
-        // given
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        postRepository.deleteAll();
+    }
+
+    @DisplayName("GET, /api/posts/{postId} 게시물 상세 정보 API")
+    @Nested
+    class getPost {
+
+        @DisplayName("게시물 상세 정보 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getPostFound() throws Exception {
+            // given
+            Post post = createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 20),
+                    List.of("초콜릿", "하늘")
+            );
+            Long postId = post.getId();
+
+            // when, then
+            mockMvc.perform(get("/api/posts/{postId}", postId))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.postId").value(postId))
+                    .andExpect(jsonPath("$.contentId").value("12345"))
+                    .andExpect(jsonPath("$.type").value("facebook"))
+                    .andExpect(jsonPath("$.title").value("강아지 해변"))
+                    .andExpect(jsonPath("$.content").value("책상 비행기 산책로"))
+                    .andExpect(jsonPath("$.hashtags").isArray())
+                    .andExpect(jsonPath("$.hashtags[0]").value("초콜릿"))
+                    .andExpect(jsonPath("$.hashtags[1]").value("하늘"))
+                    .andExpect(jsonPath("$.viewCount").value(101))
+                    .andExpect(jsonPath("$.likeCount").value(31))
+                    .andExpect(jsonPath("$.shareCount").value(11))
+                    .andExpect(jsonPath("$.createdAt").value("2023-10-10T10:10:10"))
+                    .andExpect(jsonPath("$.updatedAt").value("2023-10-10T10:10:20"));
+        }
+
+        @DisplayName("게시물을 찾을 수 없을 때 에러 응답을 보낸다.")
+        @WithMockUser
+        @Test
+        void getPostNotFound() throws Exception {
+            // given
+            List<Post> all = postRepository.findAll();
+            Assertions.assertThat(all).hasSize(0);
+
+            // when, then
+            mockMvc.perform(get("/api/posts/{postId}", 1L))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode").value(ErrorCode.POST_NOT_FOUND.name()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @DisplayName("GET, /api/posts 게시물 목록 API")
+    @Nested
+    class getPostList {
+
+        /**
+         * 테스트의 간결성, 효율성을 위해 이 외 테스트에서는 모든 필드 대신 contentId만 검증하기로 한다.
+         */
+        @DisplayName("게시물 리스트가 원한는 모양과 필드로 반환된다.")
+        @WithMockUser
+        @Test
+        void postList() throws Exception {
+            // given
+            // post, hashtag 준비 - hashtag, contentId, createdAt 제외 모든 것이 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "도서관")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[0].type").value("facebook"))
+                    .andExpect(jsonPath("$.[0].title").value("강아지 해변"))
+                    .andExpect(jsonPath("$.[0].content").value("책상 비행기 산책로"))
+                    .andExpect(jsonPath("$.[0].hashtags[0]").value("도서관"))
+                    .andExpect(jsonPath("$.[0].hashtags[1]").value("초콜릿"))
+                    .andExpect(jsonPath("$.[0].viewCount").value(101))
+                    .andExpect(jsonPath("$.[0].likeCount").value(31))
+                    .andExpect(jsonPath("$.[0].shareCount").value(11))
+                    .andExpect(jsonPath("$.[0].createdAt").value("2023-10-10T10:10:11"))
+                    .andExpect(jsonPath("$.[0].updatedAt").value("2023-10-10T10:10:10"));
+        }
+
+        @DisplayName("해시태그와 정확히 일치하는 게시물 목록을 응답한다.")
+        @WithMockUser
+        @Test
+        void givenHashtag_thenReturnPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - hashtag, contentId, creatdAt 제외 모든 것이 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("호수", "카메라")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("노래", "호수")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "호수")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[1].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("소셜 미디어 타입과 일치하는 게시물 리스트를 응답한다.")
+        @WithMockUser
+        @Test
+        void givenSnsType_thenReturnPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - type, contentId, creatdAt 제외 모든 것이 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.INSTAGRAM,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"));
+        }
+
+        @DisplayName("소셜 미디어 타입 값을 미입력 시 모든 type의 게시물이 조회된다.")
+        @WithMockUser
+        @Test
+        void givenNoSnsType_thenReturnAllTypesPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - type, contentId, creatdAt 제외 모든 것이 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.INSTAGRAM,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            //.queryParam("type", "facebook") // type 파라미터 삭제
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[2].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("소셜 미디어 타입 값이 blank 라면 모든 type의 게시물이 조회된다.")
+        @WithMockUser
+        @Test
+        void givenBlankSnsType_thenReturnAllTypesPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - type, contentId, creatdAt 제외 모든 것이 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.INSTAGRAM,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            String type = "   ";
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", type)
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[2].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("정렬 기준과 정렬 방향에 맞춰 게시물 리스트가 조회된다. 정렬 방향을 생략한 경우 asc로 취급된다.")
+        @WithMockUser
+        @MethodSource("givenOrderByArgumentsProvider")
+        @ParameterizedTest
+        void givenOrderBy_thenReturnPosts(String orderBy, List<String> expectedContentIds) throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt, updatedAt, likeCount, shareCount, viewCount 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    102L, 32L, 12L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    103L, 33L, 13L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", orderBy)
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value(expectedContentIds.get(0)))
+                    .andExpect(jsonPath("$.[1].contentId").value(expectedContentIds.get(1)))
+                    .andExpect(jsonPath("$.[2].contentId").value(expectedContentIds.get(2)));
+        }
+
+        static Stream<Arguments> givenOrderByArgumentsProvider() {
+            return Stream.of(
+                    Arguments.of("createdAt,asc", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("createdAt,desc", List.of("zxcvb", "qwerty", "12345")),
+                    Arguments.of("createdAt,", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("createdAt", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("updatedAt,asc", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("updatedAt,desc", List.of("zxcvb", "qwerty", "12345")),
+                    Arguments.of("updatedAt,", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("updatedAt", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("likeCount,asc", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("likeCount,desc", List.of("zxcvb", "qwerty", "12345")),
+                    Arguments.of("likeCount,", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("likeCount", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("shareCount,asc", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("shareCount,desc", List.of("zxcvb", "qwerty", "12345")),
+                    Arguments.of("shareCount,", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("shareCount", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("viewCount,asc", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("viewCount,desc", List.of("zxcvb", "qwerty", "12345")),
+                    Arguments.of("viewCount,", List.of("12345", "qwerty", "zxcvb")),
+                    Arguments.of("viewCount", List.of("12345", "qwerty", "zxcvb"))
+            );
+        }
+
+        @DisplayName("정렬 기준과 정렬 방향에이 제공되지 않으면 createdAt,asc 로 취급된다.")
+        @WithMockUser
+        @Test
+        void givenNullOrderBy_thenCreatedAtAsc() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt, updatedAt, likeCount, shareCount, viewCount 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    102L, 32L, 12L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    103L, 33L, 13L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            //.queryParam("orderBy", orderBy)
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[2].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("검색 영역을 제목(title)로 지정할 수 있다.")
+        @WithMockUser
+        @Test
+        void givenSearchByAsTitle_thenReturnPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt, title 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "레스토랑 산호초", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "호수 수영장 산호초", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+
+            String searchBy = "title";
+            String search = "산호초";
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", searchBy)
+                            .queryParam("search", search)
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[1].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("검색 영역을 내용(content)로 지정할 수 있다.")
+        @WithMockUser
+        @Test
+        void givenSearchByAsContent_thenReturnPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt, content 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "노래 수영장",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "스마트폰 사진 비행기",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+
+            String searchBy = "content";
+            String search = "비행기";
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", searchBy)
+                            .queryParam("search", search)
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("검색 영역을 제목,내용(title,content)으로 지정할 수 있다.")
+        @WithMockUser
+        @Test
+        void givenSearchByAsTitleAndContent_thenReturnPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt, content 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "꿈 하늘", "고양이 냇가 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "달 구름 고양이", "헤드폰 스피커 고양이",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+
+            String searchBy = "title,content";
+            String search = "고양이";
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", searchBy)
+                            .queryParam("search", search)
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[2].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("검색 영역을 지정하지 않는다면 제목, 내용으로 검색한다.")
+        @WithMockUser
+        @Test
+        void givenNullSearchBy_thenAsTitleAndContent() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt, content, title 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "꿈 하늘", "고양이 냇가 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "달 구름 고양이", "헤드폰 스피커 고양이",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+
+            String search = "고양이";
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            //.queryParam("searchBy", searchBy)
+                            .queryParam("search", search)
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[2].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("검색어를 지정하지 않는다면 검색어는 검색 조건에 들어가지 않는다.")
+        @WithMockUser
+        @Test
+        void givenNullSearch_thenNoSearchCriteria() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "title")
+                            //.queryParam("search", search)
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[2].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("페이지당 게시물 수와 페이지 번호를 지정할 수 있다.")
+        @WithMockUser
+        @Test
+        void givenPageCountAndPage() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+
+            String pageCount = "1";
+            String page = "2";
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "title")
+                            .queryParam("search", "도서관")
+                            .queryParam("pageCount", pageCount)
+                            .queryParam("page", page)
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.size()").value(1))
+                    .andExpect(jsonPath("$.[0].contentId").value("zxcvb"));
+        }
+
+        @DisplayName("페이지당 게시물 수와 페이지 번호가 제공되지 않을 경우 각 10, 0의 기본값을 갖는다.")
+        @WithMockUser
+        @Test
+        void givenNullPageCountAndPage() throws Exception {
+            // given
+            // post, hashtag 준비 - contentId, createdAt 제외 모두 동일
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "zxcvb", SnsType.FACEBOOK,
+                    "고양이 산 도서관", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                    List.of("도서관", "초콜릿")
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            .queryParam("hashtag", "초콜릿")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "title")
+                            //.queryParam("pageCount", pageCount)
+                            //.queryParam("page", page)
+                            .queryParam("search", "도서관")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.[0].contentId").value("12345"))
+                    .andExpect(jsonPath("$.[1].contentId").value("qwerty"))
+                    .andExpect(jsonPath("$.[2].contentId").value("zxcvb"));
+        }
+
+    }
+
+
+    private Post createPostAndHashtags(
+            String contentId, SnsType snsType,
+            String title, String content,
+            long viewCount, long likeCount, long shareCount,
+            LocalDateTime createdAt, LocalDateTime updatedAt,
+            List<String> hashtags
+    ) {
         Post post = Post.builder()
-                .contentId("12345")
-                .type(SnsType.FACEBOOK)
-                .title("맛집 탐방 1")
-                .content("여기 진짜 맛집인정!")
-                .viewCount(100L)
-                .likeCount(30L)
-                .shareCount(10L)
-                .createdAt(LocalDateTime.of(2023, 10, 10, 10, 10, 10))
-                .updatedAt(LocalDateTime.of(2023, 10, 10, 10, 10, 20))
+                .contentId(contentId)
+                .type(snsType)
+                .title(title)
+                .content(content)
+                .viewCount(viewCount)
+                .likeCount(likeCount)
+                .shareCount(shareCount)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
                 .build();
-        PostHashtag.builder()
-                .post(post)
-                .hashtag("맛집")
-                .build();
-        PostHashtag.builder()
-                .post(post)
-                .hashtag("Dani")
-                .build();
-        postRepository.save(post);
-        Long postId = post.getId();
-
-        // when, then
-        mockMvc.perform(get("/api/posts/{postId}", postId))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.postId").value(postId))
-                .andExpect(jsonPath("$.contentId").value("12345"))
-                .andExpect(jsonPath("$.type").value("FACEBOOK"))
-                .andExpect(jsonPath("$.title").value("맛집 탐방 1"))
-                .andExpect(jsonPath("$.content").value("여기 진짜 맛집인정!"))
-                .andExpect(jsonPath("$.hashtags").isArray())
-                .andExpect(jsonPath("$.hashtags[0]").value("맛집"))
-                .andExpect(jsonPath("$.hashtags[1]").value("Dani"))
-                .andExpect(jsonPath("$.viewCount").value(100))
-                .andExpect(jsonPath("$.likeCount").value(30))
-                .andExpect(jsonPath("$.shareCount").value(10))
-                .andExpect(jsonPath("$.createdAt").value("2023-10-10T10:10:10"))
-                .andExpect(jsonPath("$.updatedAt").value("2023-10-10T10:10:20"));
+        for (String hashtag : hashtags) {
+            PostHashtag.builder()
+                    .post(post)
+                    .hashtag(hashtag)
+                    .build();
+        }
+        return postRepository.save(post);
     }
-
-    @DisplayName("게시물을 찾을 수 없을 때 에러 응답을 보낸다.")
-    @WithMockUser
-    @Test
-    void getPostNotFound() throws Exception {
-        // given
-        List<Post> all = postRepository.findAll();
-        Assertions.assertThat(all).hasSize(0);
-
-        // when, then
-        mockMvc.perform(get("/api/posts/{postId}", 1L))
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.POST_NOT_FOUND.name()))
-                .andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND.getMessage()));
-    }
-
 }

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryTest.java
@@ -66,7 +66,7 @@ class PostRepositoryTest {
         PostSearchCondition searchCondition = PostSearchCondition.builder()
                 .hashtag("초콜릿")
                 .type(SnsType.FACEBOOK)
-                .searchBy(SearchByType.content)
+                .searchBy(SearchByType.CONTENT)
                 .search("산책로")
                 .build();
         PageRequest pageRequest = PageRequest.of(0, 10,
@@ -114,7 +114,7 @@ class PostRepositoryTest {
         PostSearchCondition searchCondition = PostSearchCondition.builder()
                 .hashtag("카메라")
                 .type(SnsType.FACEBOOK)
-                .searchBy(SearchByType.content)
+                .searchBy(SearchByType.CONTENT)
                 .search("산책로")
                 .build();
         PageRequest pageRequest = PageRequest.of(0, 10,
@@ -160,7 +160,7 @@ class PostRepositoryTest {
         PostSearchCondition searchCondition = PostSearchCondition.builder()
                 .hashtag("초콜릿")
                 .type(SnsType.FACEBOOK)
-                .searchBy(SearchByType.content)
+                .searchBy(SearchByType.CONTENT)
                 .search("산책로")
                 .build();
         PageRequest pageRequest = PageRequest.of(0, 10,
@@ -207,7 +207,7 @@ class PostRepositoryTest {
         PostSearchCondition searchCondition = PostSearchCondition.builder()
                 .hashtag("초콜릿")
                 .type(null)
-                .searchBy(SearchByType.content)
+                .searchBy(SearchByType.CONTENT)
                 .search("산책로")
                 .build();
         PageRequest pageRequest = PageRequest.of(0, 10,
@@ -255,7 +255,7 @@ class PostRepositoryTest {
         PostSearchCondition searchCondition = PostSearchCondition.builder()
                 .hashtag("초콜릿")
                 .type(SnsType.FACEBOOK)
-                .searchBy(SearchByType.content)
+                .searchBy(SearchByType.CONTENT)
                 .search("산책로")
                 .build();
         PageRequest pageRequest = PageRequest.of(0, 10,
@@ -335,9 +335,9 @@ class PostRepositoryTest {
     static Stream<Arguments> givenSearchByArgumentsProvider() {
         return Stream.of(
                 // SearchByType searchByType, String search, int expectedSize, List<String> expectedContentIds
-                Arguments.of(SearchByType.title, "해변", 2, List.of("12345", "asdfg")),
-                Arguments.of(SearchByType.content, "선물", 1, List.of("qwerty")),
-                Arguments.of(SearchByType.titleContent, "노트북", 2, List.of("12345", "qwerty"))
+                Arguments.of(SearchByType.TITLE, "해변", 2, List.of("12345", "asdfg")),
+                Arguments.of(SearchByType.CONTENT, "선물", 1, List.of("qwerty")),
+                Arguments.of(SearchByType.TITLE_CONTENT, "노트북", 2, List.of("12345", "qwerty"))
         );
     }
 
@@ -383,7 +383,7 @@ class PostRepositoryTest {
         PostSearchCondition searchCondition = PostSearchCondition.builder()
                 .hashtag("초콜릿")
                 .type(SnsType.FACEBOOK)
-                .searchBy(SearchByType.content)
+                .searchBy(SearchByType.CONTENT)
                 .search("산책로")
                 .build();
 

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/repository/PostRepositoryTest.java
@@ -1,0 +1,441 @@
+package com.wanted.teamr.snsfeedintegration.repository;
+
+import com.wanted.teamr.snsfeedintegration.domain.Post;
+import com.wanted.teamr.snsfeedintegration.domain.PostHashtag;
+import com.wanted.teamr.snsfeedintegration.domain.SearchByType;
+import com.wanted.teamr.snsfeedintegration.domain.SnsType;
+import com.wanted.teamr.snsfeedintegration.dto.PostSearchCondition;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+
+@DataJpaTest
+class PostRepositoryTest {
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    EntityManager em;
+
+
+    // TODO: hashtag이 없는 경우는 없다. 컨트롤러가 hashtag 없는 요청을 받았을 때 서비스에서 본인 계정 hashtag 넣어주도록 해야 한다.
+    @DisplayName("정확히 일치하는 hashtag의 게시물만 검색해야 합니다.")
+    @Test
+    void givenPostWithExactHashtag_thenReturnPosts() {
+        // post, hashtag 준비
+        createPostAndHashtags(
+                "12345", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "qwerty", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "asdfg", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+
+        // 검색 조건 설정
+        PostSearchCondition searchCondition = PostSearchCondition.builder()
+                .hashtag("초콜릿")
+                .type(SnsType.FACEBOOK)
+                .searchBy(SearchByType.content)
+                .search("산책로")
+                .build();
+        PageRequest pageRequest = PageRequest.of(0, 10,
+                Sort.by(Sort.Direction.ASC, "createdAt"));
+
+        // when
+        List<Post> posts = postRepository.search(searchCondition, pageRequest);
+
+        // then
+        Assertions.assertThat(posts).hasSize(3)
+                .extracting("contentId").containsExactly("12345", "qwerty", "asdfg");
+    }
+
+
+    @DisplayName("정확히 일치하는 hashtag의 게시물이 없을 경우 빈 리스트를 반환해야 합니다.")
+    @Test
+    void givenNoPostWithExactHashtag_thenReturnEmptyList() {
+        // post, hashtag 준비
+        createPostAndHashtags(
+                "12345", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "qwerty", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "asdfg", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+
+        // 어떤 게시물과도 일치하지 않는 해시태그 검색 조건 설정
+        PostSearchCondition searchCondition = PostSearchCondition.builder()
+                .hashtag("카메라")
+                .type(SnsType.FACEBOOK)
+                .searchBy(SearchByType.content)
+                .search("산책로")
+                .build();
+        PageRequest pageRequest = PageRequest.of(0, 10,
+                Sort.by(Sort.Direction.ASC, "createdAt"));
+
+        // when
+        List<Post> posts = postRepository.search(searchCondition, pageRequest);
+
+        // then
+        Assertions.assertThat(posts).hasSize(0);
+    }
+
+    @DisplayName("일치하는 소셜 미디어 타입 게시물을 검색합니다.")
+    @Test
+    void givenSocialMediaType() {
+        // post, hashtag 준비
+        createPostAndHashtags(
+                "12345", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "qwerty", SnsType.INSTAGRAM,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "asdfg", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+
+        // 검색 조건 설정
+        PostSearchCondition searchCondition = PostSearchCondition.builder()
+                .hashtag("초콜릿")
+                .type(SnsType.FACEBOOK)
+                .searchBy(SearchByType.content)
+                .search("산책로")
+                .build();
+        PageRequest pageRequest = PageRequest.of(0, 10,
+                Sort.by(Sort.Direction.ASC, "createdAt"));
+
+        // when
+        List<Post> posts = postRepository.search(searchCondition, pageRequest);
+
+        // then
+        Assertions.assertThat(posts).hasSize(2)
+                .extracting("contentId").containsExactly("12345", "asdfg");
+    }
+
+    @DisplayName("소셜 미디어 타입을 정하지 않으면 모든 타입이 조회됩니다.")
+    @Test
+    void givenNoSocialMediaType_thenSearchEveryTypes() {
+        // post, hashtag 준비
+        createPostAndHashtags(
+                "12345", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "qwerty", SnsType.INSTAGRAM,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "asdfg", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+
+        // 검색 조건 설정 - 소셜 미디어 타입 null
+        PostSearchCondition searchCondition = PostSearchCondition.builder()
+                .hashtag("초콜릿")
+                .type(null)
+                .searchBy(SearchByType.content)
+                .search("산책로")
+                .build();
+        PageRequest pageRequest = PageRequest.of(0, 10,
+                Sort.by(Sort.Direction.ASC, "createdAt"));
+
+        // when
+        List<Post> posts = postRepository.search(searchCondition, pageRequest);
+
+        // then
+        Assertions.assertThat(posts).hasSize(3)
+                .extracting("contentId").containsExactly("12345", "qwerty", "asdfg");
+    }
+
+    @DisplayName("다양한 정렬 기준(createdAt, updatedAt, likeCount, shareCount, viewCount)에 맞춰 게시물이 정렬됩니다.")
+    @MethodSource("getOrderByArgumentsProvider")
+    @ParameterizedTest
+    void givenOrderBy_ThenOrdered(String orderProperty, Sort.Direction orderDirection, List<String> expectedContentIds) {
+        // post, hashtag 준비 - post의 viewCount, likeCount, shareCount, createdAt, updatedAt 만 서로 다르게 준비
+        createPostAndHashtags(
+                "12345", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                100L, 30L, 10L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "qwerty", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "asdfg", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                102L, 32L, 12L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                List.of("도서관", "초콜릿")
+        );
+
+        // 검색 조건 설정
+        PostSearchCondition searchCondition = PostSearchCondition.builder()
+                .hashtag("초콜릿")
+                .type(SnsType.FACEBOOK)
+                .searchBy(SearchByType.content)
+                .search("산책로")
+                .build();
+        PageRequest pageRequest = PageRequest.of(0, 10,
+                Sort.by(orderDirection, orderProperty));
+
+        // when
+        List<Post> posts = postRepository.search(searchCondition, pageRequest);
+
+        // then
+        Assertions.assertThat(posts).hasSize(3)
+                .extracting("contentId").containsExactly(expectedContentIds.toArray());
+    }
+
+    static Stream<Arguments> getOrderByArgumentsProvider() {
+        return Stream.of(
+                Arguments.of("createdAt", Sort.Direction.ASC, List.of("12345", "qwerty", "asdfg")),
+                Arguments.of("createdAt", Sort.Direction.DESC, List.of("asdfg", "qwerty", "12345")),
+                Arguments.of("updatedAt", Sort.Direction.ASC, List.of("12345", "qwerty", "asdfg")),
+                Arguments.of("updatedAt", Sort.Direction.DESC, List.of("asdfg", "qwerty", "12345")),
+                Arguments.of("likeCount", Sort.Direction.ASC, List.of("12345", "qwerty", "asdfg")),
+                Arguments.of("likeCount", Sort.Direction.DESC, List.of("asdfg", "qwerty", "12345")),
+                Arguments.of("shareCount", Sort.Direction.ASC, List.of("12345", "qwerty", "asdfg")),
+                Arguments.of("shareCount", Sort.Direction.DESC, List.of("asdfg", "qwerty", "12345")),
+                Arguments.of("viewCount", Sort.Direction.ASC, List.of("12345", "qwerty", "asdfg")),
+                Arguments.of("viewCount", Sort.Direction.DESC, List.of("asdfg", "qwerty", "12345"))
+        );
+    }
+
+    @DisplayName("다양한 검색 기준(title, content, title,content)에 맞게 게시물을 검색합니다.")
+    @MethodSource("givenSearchByArgumentsProvider")
+    @ParameterizedTest
+    void givenSearchBy(SearchByType searchByType, String search, int expectedSize, List<String> expectedContentIds) {
+        // post, hashtag 준비 - title과 content만 다르게 준비
+        createPostAndHashtags(
+                "12345", SnsType.FACEBOOK,
+                "강아지 해변", "책상 노트북 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "qwerty", SnsType.FACEBOOK,
+                "공원 노트북", "휴가 선물 모자",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "asdfg", SnsType.FACEBOOK,
+                "해변 신발", "고양이 자전거 도서관",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+
+        // 검색 조건 설정
+        PostSearchCondition searchCondition = PostSearchCondition.builder()
+                .hashtag("초콜릿")
+                .type(SnsType.FACEBOOK)
+                .searchBy(searchByType)
+                .search(search)
+                .build();
+        PageRequest pageRequest = PageRequest.of(0, 10,
+                Sort.by(Sort.Direction.ASC, "createdAt"));
+
+        // when
+        List<Post> posts = postRepository.search(searchCondition, pageRequest);
+
+        // then
+        Assertions.assertThat(posts).hasSize(expectedSize)
+                .extracting("contentId").containsExactly(expectedContentIds.toArray());
+    }
+
+    static Stream<Arguments> givenSearchByArgumentsProvider() {
+        return Stream.of(
+                // SearchByType searchByType, String search, int expectedSize, List<String> expectedContentIds
+                Arguments.of(SearchByType.title, "해변", 2, List.of("12345", "asdfg")),
+                Arguments.of(SearchByType.content, "선물", 1, List.of("qwerty")),
+                Arguments.of(SearchByType.titleContent, "노트북", 2, List.of("12345", "qwerty"))
+        );
+    }
+
+    @DisplayName("페이지 당 게시물 갯수와 조회하려는 페이지를 지정할 수 있습니다.")
+    @MethodSource("givenPageCountAndPageArgumentsProvider")
+    @ParameterizedTest
+    void givenPageCountAndPage(int pageNumber, int pageSize, int expectedSize, List<String> expectedContentIds) {
+        // post, hashtag 준비 - createdAt 제외 모든 값 도일
+        createPostAndHashtags(
+                "12345", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "qwerty", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 11),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "asdfg", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 12),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+        createPostAndHashtags(
+                "jkl", SnsType.FACEBOOK,
+                "강아지 해변", "책상 비행기 산책로",
+                101L, 31L, 11L,
+                LocalDateTime.of(2023, 10, 10, 10, 10, 13),
+                LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                List.of("도서관", "초콜릿")
+        );
+
+        // 검색 조건 설정 - 모든 게시물 선택
+        PostSearchCondition searchCondition = PostSearchCondition.builder()
+                .hashtag("초콜릿")
+                .type(SnsType.FACEBOOK)
+                .searchBy(SearchByType.content)
+                .search("산책로")
+                .build();
+
+        // 페이지 설정 - argument 대입
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize,
+                Sort.by(Sort.Direction.ASC, "createdAt"));
+
+        // when
+        List<Post> posts = postRepository.search(searchCondition, pageRequest);
+
+        // then
+        Assertions.assertThat(posts).hasSize(expectedSize)
+                .extracting("contentId").containsExactly(expectedContentIds.toArray());
+    }
+
+    static Stream<Arguments> givenPageCountAndPageArgumentsProvider() {
+        return Stream.of(
+                // int pageNumber, int pageSize, int expectedSize, List<String> expectedContentIds
+                Arguments.of(0, 4, 4, List.of("12345", "qwerty", "asdfg", "jkl")),
+                Arguments.of(0, 5, 4, List.of("12345", "qwerty", "asdfg", "jkl")),
+                Arguments.of(0, 2, 2, List.of("12345", "qwerty")),
+                Arguments.of(1, 2, 2, List.of("asdfg", "jkl")),
+                Arguments.of(1, 1, 1, List.of("qwerty")),
+                Arguments.of(5, 1, 0, List.of())
+        );
+    }
+
+    private Post createPostAndHashtags(
+            String contentId, SnsType snsType,
+            String title, String content,
+            long viewCount, long likeCount, long shareCount,
+            LocalDateTime createdAt, LocalDateTime updatedAt,
+            List<String> hashtags
+    ) {
+        Post post = Post.builder()
+                .contentId(contentId)
+                .type(snsType)
+                .title(title)
+                .content(content)
+                .viewCount(viewCount)
+                .likeCount(likeCount)
+                .shareCount(shareCount)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+        for (String hashtag : hashtags) {
+            PostHashtag.builder()
+                    .post(post)
+                    .hashtag(hashtag)
+                    .build();
+        }
+        return postRepository.save(post);
+    }
+
+}

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceConcurrencyTest.java
@@ -55,7 +55,7 @@ class PostServiceConcurrencyTest {
                 try {
                     postService.likePost(post.getId());
                 } catch (CustomException ex) {
-                    System.out.println(ex.getErrorCode());
+                    System.out.println(ex.getErrorCodeType().getMessage());
                 } catch (Exception ex) {
                     System.out.println(ex);
                 } finally {

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
@@ -87,7 +87,7 @@ class PostServiceMockTest {
         // when, then
         assertThatThrownBy(() -> postService.getPost(postId))
                 .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
+                .extracting("errorCodeType")
                 .isEqualTo(ErrorCode.POST_NOT_FOUND);
     }
 

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/service/PostServiceMockTest.java
@@ -70,7 +70,7 @@ class PostServiceMockTest {
                         "createdAt", "updatedAt"
                 )
                 .containsExactly(
-                        "12345", "FACEBOOK", "맛집 탐방 1", "여기 진짜 맛집인정!",
+                        "12345", "facebook", "맛집 탐방 1", "여기 진짜 맛집인정!",
                         List.of("맛집", "Dani"), 100L, 30L, 10L,
                         LocalDateTime.of(2023, 10, 10, 10, 10, 10),
                         LocalDateTime.of(2023, 10, 10, 10, 10, 20)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,5 +12,6 @@ spring:
         format_sql: true
     show-sql: true
   config:
-    import: external-api-config.yml
-
+    import:
+      - external-api-config.yml
+      - pageable-config.yml

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,3 +15,6 @@ spring:
     import:
       - external-api-config.yml
       - pageable-config.yml
+  h2:
+    console:
+      enabled: true


### PR DESCRIPTION
## 📃 설명

- resolves #26 

## 🔨 작업 내용

1.  게시물 리스트 조회 API 구현하였습니다.
2. Querydsl을 이용해 동적 쿼리, 정렬, 페이징 처리하였습니다.

## 💬 기타 사항

- 