### PR TITLE
refactor #34: `MemberService` 공통 로직 추출 및 불필요 코드 제거

### DIFF
--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/AccountInfo.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/AccountInfo.java
@@ -1,0 +1,8 @@
+package com.wanted.teamr.snsfeedintegration.dto;
+
+public interface AccountInfo {
+
+    String getAccountName();
+    String getPassword();
+
+}

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberApprovalRequest.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberApprovalRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
-public class MemberApprovalRequest {
+public class MemberApprovalRequest implements AccountInfo {
 
     @NotBlank
     private String accountName;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberLogInRequest.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/dto/MemberLogInRequest.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 @Getter
 @NoArgsConstructor
-public class MemberLogInRequest {
+public class MemberLogInRequest implements AccountInfo {
 
     @NotBlank
     private String accountName;

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/exception/ErrorCode.java
@@ -25,7 +25,6 @@ public enum ErrorCode implements ErrorCodeType {
     ILLEGAL_TOKEN("JWT 토큰이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
     NOT_SAME_AUTHORITY("권한이 일치하지 않습니다", HttpStatus.BAD_REQUEST),
     REQUIRE_AUTHORITY("필요한 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    WRONG_ACCOUNT_INFO("아이디가 없거나 비밀번호가 틀렸습니다.", HttpStatus.NOT_FOUND),
     REQUIRE_APPROVAL("가입승인이 필요합니다.", HttpStatus.BAD_REQUEST),
 
     POST_NOT_FOUND("게시물이 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/MemberControllerTest.java
@@ -154,7 +154,6 @@ class MemberControllerTest {
                     .andExpect(status().isCreated())
                     .andDo(print())
                     .andReturn();
-
         }
 
         @Order(2)
@@ -163,11 +162,11 @@ class MemberControllerTest {
         void loginfailedbyNotFound() throws Exception {
             MemberLogInRequest dto = MemberLogInRequest.of("name", PASSWORD);
             String content = mapper.writeValueAsString(dto);
-            ErrorCode errorCode = ErrorCode.WRONG_ACCOUNT_INFO;
+            ErrorCode errorCode = ErrorCode.ACCOUNT_INFO_WRONG;
             mockMvc.perform(post(URI)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(content))
-                    .andExpect(status().isNotFound())
+                    .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errorCode").value(errorCode.name()))
                     .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
                     .andDo(print())
@@ -180,11 +179,11 @@ class MemberControllerTest {
         void loginfailedbyWrongPassword() throws Exception {
             MemberLogInRequest dto = MemberLogInRequest.of(ACCOUNT_NAME, "11111111");
             String content = mapper.writeValueAsString(dto);
-            ErrorCode errorCode = ErrorCode.WRONG_ACCOUNT_INFO;
+            ErrorCode errorCode = ErrorCode.ACCOUNT_INFO_WRONG;
             mockMvc.perform(post(URI)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(content))
-                    .andExpect(status().isNotFound())
+                    .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errorCode").value(errorCode.name()))
                     .andExpect(jsonPath("$.message").value(errorCode.getMessage()))
                     .andDo(print())


### PR DESCRIPTION
## 📃 설명

- resolves #34 

## 💬 기타 사항

- 에러코드 ACCOUNT_INFO_WRONG (계정 이름 또는 비밀번호가 잘못되어 사용자를 찾을 수 없을 때) 404 Not Found vs 400 Bad Request 뭐가 맞을까요? 저는 요청의 입력이 잘못됐다고 어필하기 위해 후자가 맞는 것 같아서 그렇게 바꿔봤습니다.