### PR TITLE
feature #39: 게시물 리스트 API에 hashtag 기본 검색어어를 사용자의 계정명으로 적용

### DIFF
--- a/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/controller/PostController.java
@@ -27,8 +27,9 @@ public class PostController {
     }
 
     @GetMapping("/api/posts")
-    public List<PostGetResponse> getPostList(PostSearchRequest request, Pageable pageable) {
-        return postService.getPostList(request, pageable);
+    public List<PostGetResponse> getPostList(PostSearchRequest request, Pageable pageable,
+                                             @CurrentMember Member member) {
+        return postService.getPostList(request, pageable, member);
     }
 
     @PostMapping("/api/posts/{postId}/like")

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/service/PostService.java
@@ -32,8 +32,10 @@ public class PostService {
         return PostGetResponse.of(post);
     }
 
-    public List<PostGetResponse> getPostList(PostSearchRequest request, Pageable pageable) {
-        PostSearchCondition condition = converter.convert(request);
+    public List<PostGetResponse> getPostList(PostSearchRequest request, Pageable pageable,
+                                             Member member) {
+        String accountName = member.getAccountName();
+        PostSearchCondition condition = converter.convert(request, accountName);
         List<Post> posts = postRepository.search(condition, pageable);
         return posts.stream().map(PostGetResponse::of).toList();
     }

--- a/src/main/java/com/wanted/teamr/snsfeedintegration/util/PostSearchConditionConverter.java
+++ b/src/main/java/com/wanted/teamr/snsfeedintegration/util/PostSearchConditionConverter.java
@@ -13,15 +13,17 @@ import static org.springframework.util.StringUtils.hasText;
 @Component
 public class PostSearchConditionConverter {
 
-    public PostSearchCondition convert(PostSearchRequest request) {
-        String hashtag = resolveHashtag(request.getHashtag());
+    public PostSearchCondition convert(PostSearchRequest request, String defaultHashtag) {
+        String hashtag = resolveHashtag(request.getHashtag(), defaultHashtag);
         SnsType snsType = resolveSnsType(request.getType());
         SearchByType searchByType = resolveSearchBy(request.getSearchBy());
         return PostSearchCondition.of(hashtag, snsType, searchByType, request.getSearch());
     }
 
-    private String resolveHashtag(String hashtag) {
-        // TODO: 만약 이 값이 null 이면 본인계정 hashtag 값을 사용한다.
+    private String resolveHashtag(String hashtag, String defaultHashtag) {
+        if (hashtag == null) {
+            return defaultHashtag;
+        }
         return hashtag;
     }
 

--- a/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
+++ b/src/test/java/com/wanted/teamr/snsfeedintegration/controller/PostControllerTest.java
@@ -211,6 +211,45 @@ public class PostControllerTest {
                     .andExpect(jsonPath("$.[1].contentId").value("zxcvb"));
         }
 
+        @DisplayName("검색 조건으로 해시태그 값이 미입력 시 사용자 계정이름을 해시태그로 사용하여 검색한다..")
+        @WithAuthUser
+        @Test
+        void givenBlankHashtag_thenReturnPosts() throws Exception {
+            // given
+            // post, hashtag 준비 - hashtag, contentId 제외 모든 것이 동일
+            String accountName = "testId";
+            createPostAndHashtags(
+                    "12345", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of("도서관", "초콜릿")
+            );
+            createPostAndHashtags(
+                    "qwerty", SnsType.FACEBOOK,
+                    "강아지 해변", "책상 비행기 산책로",
+                    101L, 31L, 11L,
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    LocalDateTime.of(2023, 10, 10, 10, 10, 10),
+                    List.of(accountName)
+            );
+
+            // when, then
+            mockMvc.perform(get("/api/posts")
+                            //.queryParam("hashtag", "호수")
+                            .queryParam("type", "facebook")
+                            .queryParam("orderBy", "createdAt,asc")
+                            .queryParam("searchBy", "content")
+                            .queryParam("search", "책상")
+                            .queryParam("pageCount", "10")
+                            .queryParam("page", "0")
+                    )
+                    .andDo(print())
+                    .andExpect(jsonPath("$.size()").value(1))
+                    .andExpect(jsonPath("$.[0].contentId").value("qwerty"));
+        }
+
         @DisplayName("소셜 미디어 타입과 일치하는 게시물 리스트를 응답한다.")
         @WithMockUser
         @Test


### PR DESCRIPTION
## 📃 설명

- resolves #39
- 

## 🔨 작업 내용

1. @CurrentMember를 이용해 현재 인증된 Member를 가져옵니다. Member의 accountName을 hashtag가 전달되지 않은 경우 hashtag으로 검색합니다.
2. 통합테스트에서도 @WithAuthUser 애노테이션을 이용해 위 시나리오를 검증하였습니다.

## 💬 기타 사항

- 